### PR TITLE
add lifecycle hook feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,39 @@ stacks:
         - echo test
         - service hello stop
 
+    # lifecycle hooks
+    lifecycle_hooks:
+      # Lifecycle hooks for launching new instances
+      launch_transition:
+        - lifecycle_hook_name: hello-launch-lifecycle-hook
+
+          # The maximum time, in seconds, that can elapse before the lifecycle hook times
+          # out.
+          #
+          # If the lifecycle hook times out, Amazon EC2 Auto Scaling performs the action
+          # that you specified in the `default_result` parameter.
+          heartbeat_timeout: 30
+
+          # Defines the action the Auto Scaling group should take when the lifecycle
+          # hook timeout elapses or if an unexpected failure occurs. The valid values
+          # are CONTINUE and ABANDON. The default value is ABANDON.
+          default_result: CONTINUE
+
+          # Additional information that you want to include any time Amazon EC2 AutoScaling sends a message to the notification target.
+          notification_metadata: "this is test for launching"
+
+          # The ARN of the target that Amazon EC2 Auto Scaling sends notifications to
+          # when an instance is in the transition state for the lifecycle hook. The notification
+          # target can be either an SQS queue or an SNS topic.
+          notification_target_arn: arn:aws:sns:ap-northeast-2:816736805842:test
+
+          # The ARN of the IAM role that allows the Auto Scaling group to publish to
+          # the specified notification target, for example, an Amazon SNS topic or an
+          # Amazon SQS queue.
+          # This is required if `notification_target_arn is not empty
+          role_arn: arn:aws:iam::816736805842:role/test-autoscaling-role
+
+
     # list of region
     # deployer will concurrently deploy across the region
     regions:

--- a/configs/hello.yaml
+++ b/configs/hello.yaml
@@ -248,6 +248,48 @@ stacks:
         - echo test
         - service hello stop
 
+    # lifecycle hooks
+    lifecycle_hooks:
+      # Lifecycle hooks for launching new instances
+      launch_transition:
+        - lifecycle_hook_name: hello-launch-lifecycle-hook
+
+          # The maximum time, in seconds, that can elapse before the lifecycle hook times
+          # out.
+          #
+          # If the lifecycle hook times out, Amazon EC2 Auto Scaling performs the action
+          # that you specified in the `default_result` parameter.
+          heartbeat_timeout: 30
+
+          # Defines the action the Auto Scaling group should take when the lifecycle
+          # hook timeout elapses or if an unexpected failure occurs. The valid values
+          # are CONTINUE and ABANDON. The default value is ABANDON.
+          default_result: CONTINUE
+
+          # Additional information that you want to include any time Amazon EC2 AutoScaling sends a message to the notification target.
+          notification_metadata: "this is test for launching"
+
+          # The ARN of the target that Amazon EC2 Auto Scaling sends notifications to
+          # when an instance is in the transition state for the lifecycle hook. The notification
+          # target can be either an SQS queue or an SNS topic.
+          notification_target_arn: arn:aws:sns:ap-northeast-2:816736805842:test
+
+          # The ARN of the IAM role that allows the Auto Scaling group to publish to
+          # the specified notification target, for example, an Amazon SNS topic or an
+          # Amazon SQS queue.
+          # This is required if `notification_target_arn is not empty
+          role_arn: arn:aws:iam::816736805842:role/test-autoscaling-role
+
+      # Lifecycle hooks for terminating instances
+      #terminate_transition:
+      #  - lifecycle_hook_name: hello-terminate-lifecycle-hook
+      #    heartbeat_timeout: 30
+      #    default_result: CONTINUE
+      #    notification_metadata: ""
+      #    notification_target_arn: arn:aws:sns:ap-northeast-2:816736805842:test
+      #    role_arn: arn:aws:iam::816736805842:role/test-autoscaling-role
+
+
     # list of region
     # deployer will concurrently deploy across the region
     regions:

--- a/pkg/deployer/bluegreen.go
+++ b/pkg/deployer/bluegreen.go
@@ -149,6 +149,7 @@ func (b BlueGreen) Deploy(config builder.Config) {
 		targetGroupArns := client.ELBService.GetTargetGroupARNs(targetGroups)
 		tags := client.EC2Service.GenerateTags(b.AwsConfig.Tags, new_asg_name, b.AwsConfig.Name, config.Stack, b.Stack.AnsibleTags, config.ExtraTags, config.AnsibleExtraVars)
 		subnets := client.EC2Service.GetSubnets(region.VPC, usePublicSubnets, availabilityZones)
+		lifecycleHooksSpecificationList := client.EC2Service.GenerateLifecycleHooks(b.Stack.LifecycleHooks)
 
 		ret = client.EC2Service.CreateAutoScalingGroup(
 			new_asg_name,
@@ -163,6 +164,7 @@ func (b BlueGreen) Deploy(config builder.Config) {
 			tags,
 			subnets,
 			b.Stack.MixedInstancesPolicy,
+			lifecycleHooksSpecificationList,
 		)
 
 		if !ret {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #3 <!-- tracking issues that this PR will close -->
**Related**: lifecycle hooks feature

**Description**
You could use `lifecycle hooks` feature of autoscaling group. This could be helpful if you have to do some stuff before launching or terminating instances like notification or upload logs to somewhere  etc.
