### PR TITLE
add override-instance-type arguement

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,18 @@ If other autoscaling groups of sample application already existed, for example `
 ## # How to run goployer
 * Before applying goployer, please make sure that you have made [manifest](#Manifest).
 * Here are options you can use with command line
-    * `--manifest` : manifest file path
+    * `--manifest` : manifest file path (required)
+    * `--stack` : the stack value you want to use for deployment (required)
+    * `--region` : the ID of region to which you want to deploy instances
     * `--ami` : AMI ID
     * `--assume-role` : arn of IAM role you want to assume
-    * `--stack` : the stack value you want to use for deployment
-    * `--region` : the ID of region to which you want to deploy instances
+    * `--timeout` : timeout duration of total deployment process in minute. (default: 60 minutes)
     * `--slack-off` : whether turning off slack alarm or not. (default: false)
     * `--log-level` : level of Log (debug, info, error)
     * `--extra-tags` : extra tags to set from command line. comma-delimited string(no space between tags)
         -  ex) `--extra-tags=key1=value1,key2=value2`
     * `--ansible-extra-vars` : extra variables to be used in ansible. Will be added to tag with `ansible-extra-vars` key.
+    * `--override-instance-type` : instance type you want to override when running goployer command.
 * If you sepcifies `--ami`, then you must have only one region in a stack or use `--region` option together.
 * You *cannot run goployer from local environment* for security & management issue.
 ```bash

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -37,19 +37,20 @@ type Builder struct {
 }
 
 type Config struct {
-	Manifest         string
-	Ami              string
-	Env              string
-	Stack            string
-	AssumeRole       string
-	Timeout          int64
-	StartTimestamp   int64
-	Region           string
-	Confirm          bool
-	SlackOff         bool
-	LogLevel         string
-	ExtraTags        string
-	AnsibleExtraVars string
+	Manifest             string
+	Ami                  string
+	Env                  string
+	Stack                string
+	AssumeRole           string
+	Timeout              int64
+	StartTimestamp       int64
+	Region               string
+	Confirm              bool
+	SlackOff             bool
+	LogLevel             string
+	ExtraTags            string
+	AnsibleExtraVars     string
+	OverrideInstanceType string
 }
 
 type YamlConfig struct {
@@ -477,23 +478,25 @@ func argumentParsing() Config {
 	logLevel := flag.String("log-level", "info", "log level")
 	extraTags := flag.String("extra-tags", "", "Extra tags to add to autoscaling group tags")
 	ansibleExtraVars := flag.String("ansible-extra-vars", "", "Extra variables for ansible")
+	overrideInstanceType := flag.String("override-instance-type", "", "Instance Type to override")
 
 	flag.Parse()
 
 	config := Config{
-		Manifest:         *manifest,
-		Ami:              *ami,
-		Env:              *env,
-		Stack:            *stack,
-		Region:           *region,
-		AssumeRole:       *assumeRole,
-		Timeout:          *timeout,
-		StartTimestamp:   time.Now().Unix(),
-		Confirm:          *confirm,
-		SlackOff:         *slackOff,
-		LogLevel:         *logLevel,
-		ExtraTags:        *extraTags,
-		AnsibleExtraVars: *ansibleExtraVars,
+		Manifest:             *manifest,
+		Ami:                  *ami,
+		Env:                  *env,
+		Stack:                *stack,
+		Region:               *region,
+		AssumeRole:           *assumeRole,
+		Timeout:              *timeout,
+		StartTimestamp:       time.Now().Unix(),
+		Confirm:              *confirm,
+		SlackOff:             *slackOff,
+		LogLevel:             *logLevel,
+		ExtraTags:            *extraTags,
+		AnsibleExtraVars:     *ansibleExtraVars,
+		OverrideInstanceType: *overrideInstanceType,
 	}
 
 	return config

--- a/pkg/deployer/bluegreen.go
+++ b/pkg/deployer/bluegreen.go
@@ -97,6 +97,16 @@ func (b BlueGreen) Deploy(config builder.Config) {
 		blockDevices := client.EC2Service.MakeLaunchTemplateBlockDeviceMappings(b.Stack.BlockDevices)
 		ebsOptimized := b.Stack.EbsOptimized
 
+		// Instance Type Override
+		instanceType := region.InstanceType
+		if len(config.OverrideInstanceType) > 0 {
+			instanceType = config.OverrideInstanceType
+
+			if b.Stack.MixedInstancesPolicy.Enabled {
+				Logger.Warnf("--override-instance-type won't be applied because mixed_instances_policy is enabled")
+			}
+		}
+
 		// Launch Configuration
 		//ret := client.EC2Service.CreateNewLaunchConfiguration(
 		//	launch_configuration_name,
@@ -114,7 +124,7 @@ func (b BlueGreen) Deploy(config builder.Config) {
 		ret := client.EC2Service.CreateNewLaunchTemplate(
 			launch_template_name,
 			ami,
-			region.InstanceType,
+			instanceType,
 			region.SshKey,
 			b.Stack.IamInstanceProfile,
 			userdata,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #14  <!-- tracking issues that this PR will close -->

**Description**
add `--override-instance-type` in order to override instance type immediately with command. This could be needed when user wants to change instance type dynamically and frequently. 

**User facing changes (remove if N/A)**
User does not need to modify manifest file for changing instance type.



<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage!
Integration tests are sometimes an appropriate substitute.
-->
