### PR TITLE
create metrics for deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 ./configs/*
+website

--- a/configs/hello.yaml
+++ b/configs/hello.yaml
@@ -272,13 +272,13 @@ stacks:
           # The ARN of the target that Amazon EC2 Auto Scaling sends notifications to
           # when an instance is in the transition state for the lifecycle hook. The notification
           # target can be either an SQS queue or an SNS topic.
-          notification_target_arn: arn:aws:sns:ap-northeast-2:816736805842:test
+          #notification_target_arn: arn:aws:sns:ap-northeast-2:816736805842:test
 
           # The ARN of the IAM role that allows the Auto Scaling group to publish to
           # the specified notification target, for example, an Amazon SNS topic or an
           # Amazon SQS queue.
           # This is required if `notification_target_arn is not empty
-          role_arn: arn:aws:iam::816736805842:role/test-autoscaling-role
+          #role_arn: arn:aws:iam::816736805842:role/test-autoscaling-role
 
       # Lifecycle hooks for terminating instances
       #terminate_transition:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/DevopsArtFactory/goployer
 go 1.14
 
 require (
-	github.com/aws/aws-sdk-go v1.31.0
+	github.com/aws/aws-sdk-go v1.33.6
 	github.com/fatih/color v1.9.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/slack-go/slack v0.6.4

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,9 @@
 github.com/aws/aws-sdk-go v1.31.0 h1:ITLZ0oy7IOB1NGt2Ee75bLevBaH1jaAXE2eyGbPRbCg=
 github.com/aws/aws-sdk-go v1.31.0/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.33.6 h1:YLoUeMSx05kHwhS+HLDSpdYYpPzJMyp6hn1cWsJ6a+U=
+github.com/aws/aws-sdk-go v1.33.6/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
@@ -19,6 +22,7 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
@@ -26,6 +30,7 @@ github.com/slack-go/slack v0.6.4 h1:cxOqFgM5RW6mdEyDqAJutFk3qiORK9oHRKi5bPqkY9o=
 github.com/slack-go/slack v0.6.4/go.mod h1:sGRjv3w+ERAUMMMbldHObQPBcNSyVB7KLKYfnwUFBfw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -1,0 +1,4 @@
+region: ap-northeast-2
+storage:
+  type: dynamodb
+  name: goployer-metrics

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -20,6 +20,11 @@ type AWSClient struct {
 	SSMService        SSMClient
 }
 
+type MetricClient struct {
+	Region          string
+	DynamoDBService DynamoDBClient
+}
+
 func getAwsSession() *session.Session {
 	mySession := session.Must(session.NewSession())
 	return mySession
@@ -53,6 +58,23 @@ func BootstrapServices(region string, assume_role string) AWSClient {
 		ELBService:        NewELBV2Client(aws_session, region, creds),
 		CloudWatchService: NewCloudWatchClient(aws_session, region, creds),
 		SSMService:        NewSSMClient(aws_session, region, creds),
+	}
+
+	return client
+}
+
+func BootstrapMetricService(region string, assume_role string) MetricClient {
+	aws_session := getAwsSession()
+
+	var creds *credentials.Credentials
+	if len(assume_role) != 0 {
+		creds = stscreds.NewCredentials(aws_session, assume_role)
+	}
+
+	//Get all clients
+	client := MetricClient{
+		Region:          region,
+		DynamoDBService: NewDynamoDBClient(aws_session, region, creds),
 	}
 
 	return client

--- a/pkg/aws/dynamodb.go
+++ b/pkg/aws/dynamodb.go
@@ -1,0 +1,283 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/DevopsArtFactory/goployer/pkg/tool"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	Logger "github.com/sirupsen/logrus"
+	"time"
+)
+
+var (
+	hashKey            = "identifier"
+	statusTimeStampKey = map[string]string{
+		"deployed":   "deployed_date_kst",
+		"terminated": "terminated_date_kst",
+	}
+	DEFAULT_READ_THROUGHPUT  = int64(5)
+	DEFAULT_WRITE_THROUGHPUT = int64(5)
+)
+
+type DynamoDBClient struct {
+	Client *dynamodb.DynamoDB
+}
+
+func NewDynamoDBClient(session *session.Session, region string, creds *credentials.Credentials) DynamoDBClient {
+	return DynamoDBClient{
+		Client: getDynamoDBClientFn(session, region, creds),
+	}
+}
+
+func getDynamoDBClientFn(session *session.Session, region string, creds *credentials.Credentials) *dynamodb.DynamoDB {
+	if creds == nil {
+		return dynamodb.New(session, &aws.Config{Region: aws.String(region)})
+	}
+	return dynamodb.New(session, &aws.Config{Region: aws.String(region), Credentials: creds})
+}
+
+func (d DynamoDBClient) CheckTableExists(tableName string) (bool, error) {
+	input := &dynamodb.DescribeTableInput{
+		TableName: aws.String(tableName),
+	}
+
+	result, err := d.Client.DescribeTable(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case dynamodb.ErrCodeResourceNotFoundException:
+				fmt.Println(dynamodb.ErrCodeResourceNotFoundException, aerr.Error())
+				return false, nil
+			case dynamodb.ErrCodeInternalServerError:
+				fmt.Println(dynamodb.ErrCodeInternalServerError, aerr.Error())
+			default:
+				fmt.Println(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and
+			// Message from an error.
+			fmt.Println(err.Error())
+		}
+		return false, err
+	}
+
+	if result.Table == nil {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (d DynamoDBClient) CreateTable(tableName string) error {
+	input := &dynamodb.CreateTableInput{
+		AttributeDefinitions: []*dynamodb.AttributeDefinition{
+			{
+				AttributeName: aws.String(hashKey),
+				AttributeType: aws.String("S"),
+			},
+		},
+		KeySchema: []*dynamodb.KeySchemaElement{
+			{
+				AttributeName: aws.String(hashKey),
+				KeyType:       aws.String("HASH"),
+			},
+		},
+		ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
+			ReadCapacityUnits:  aws.Int64(DEFAULT_WRITE_THROUGHPUT),
+			WriteCapacityUnits: aws.Int64(DEFAULT_READ_THROUGHPUT),
+		},
+		TableName: aws.String(tableName),
+	}
+
+	_, err := d.Client.CreateTable(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case dynamodb.ErrCodeResourceInUseException:
+				fmt.Println(dynamodb.ErrCodeResourceInUseException, aerr.Error())
+			case dynamodb.ErrCodeLimitExceededException:
+				fmt.Println(dynamodb.ErrCodeLimitExceededException, aerr.Error())
+			case dynamodb.ErrCodeInternalServerError:
+				fmt.Println(dynamodb.ErrCodeInternalServerError, aerr.Error())
+			default:
+				fmt.Println(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and
+			// Message from an error.
+			fmt.Println(err.Error())
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (d DynamoDBClient) MakeRecord(stack, config, tags string, asg string, tableName string, status string) error {
+	input := &dynamodb.PutItemInput{
+		Item: map[string]*dynamodb.AttributeValue{
+			"identifier": {
+				S: aws.String(asg),
+			},
+			"deployment_status": {
+				S: aws.String(status),
+			},
+			"stack": {
+				S: aws.String(stack),
+			},
+			"config": {
+				S: aws.String(config),
+			},
+			"start_date_kst": {
+				S: aws.String(tool.GetKstTimestamp().Format(time.RFC3339)),
+			},
+			"tag": {
+				S: aws.String(tags),
+			},
+		},
+		TableName: aws.String(tableName),
+	}
+
+	_, err := d.Client.PutItem(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case dynamodb.ErrCodeConditionalCheckFailedException:
+				fmt.Println(dynamodb.ErrCodeConditionalCheckFailedException, aerr.Error())
+			case dynamodb.ErrCodeProvisionedThroughputExceededException:
+				fmt.Println(dynamodb.ErrCodeProvisionedThroughputExceededException, aerr.Error())
+			case dynamodb.ErrCodeResourceNotFoundException:
+				fmt.Println(dynamodb.ErrCodeResourceNotFoundException, aerr.Error())
+			case dynamodb.ErrCodeItemCollectionSizeLimitExceededException:
+				fmt.Println(dynamodb.ErrCodeItemCollectionSizeLimitExceededException, aerr.Error())
+			case dynamodb.ErrCodeTransactionConflictException:
+				fmt.Println(dynamodb.ErrCodeTransactionConflictException, aerr.Error())
+			case dynamodb.ErrCodeRequestLimitExceeded:
+				fmt.Println(dynamodb.ErrCodeRequestLimitExceeded, aerr.Error())
+			case dynamodb.ErrCodeInternalServerError:
+				fmt.Println(dynamodb.ErrCodeInternalServerError, aerr.Error())
+			default:
+				fmt.Println(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and
+			// Message from an error.
+			fmt.Println(err.Error())
+		}
+		return err
+	}
+
+	Logger.Debugf("deployment metric is saved")
+
+	return nil
+}
+
+func (d DynamoDBClient) UpdateRecord(updateKey, asg string, tableName string, status string, updateFields map[string]string) error {
+	baseEx := "SET #S = :status, #T = :timestamp"
+
+	input := &dynamodb.UpdateItemInput{
+		ExpressionAttributeNames: map[string]*string{
+			"#S": aws.String(updateKey),
+			"#T": aws.String(statusTimeStampKey[status]),
+		},
+		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+			":status": {
+				S: aws.String(status),
+			},
+			":timestamp": {
+				S: aws.String(tool.GetKstTimestamp().Format(time.RFC3339)),
+			},
+		},
+		Key: map[string]*dynamodb.AttributeValue{
+			hashKey: {
+				S: aws.String(asg),
+			},
+		},
+		TableName:        aws.String(tableName),
+		UpdateExpression: aws.String(baseEx),
+	}
+
+	if updateFields != nil && len(updateFields) > 0 {
+		ex := baseEx
+		for k, v := range updateFields {
+			ex = fmt.Sprintf("%s, #%s = :%s", ex, k, k)
+			input.UpdateExpression = aws.String(ex)
+			input.ExpressionAttributeValues[fmt.Sprintf(":%s", k)] = &dynamodb.AttributeValue{
+				S: aws.String(v),
+			}
+			input.ExpressionAttributeNames[fmt.Sprintf("#%s", k)] = aws.String(k)
+		}
+	}
+
+	_, err := d.Client.UpdateItem(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case dynamodb.ErrCodeConditionalCheckFailedException:
+				fmt.Println(dynamodb.ErrCodeConditionalCheckFailedException, aerr.Error())
+			case dynamodb.ErrCodeProvisionedThroughputExceededException:
+				fmt.Println(dynamodb.ErrCodeProvisionedThroughputExceededException, aerr.Error())
+			case dynamodb.ErrCodeResourceNotFoundException:
+				fmt.Println(dynamodb.ErrCodeResourceNotFoundException, aerr.Error())
+			case dynamodb.ErrCodeItemCollectionSizeLimitExceededException:
+				fmt.Println(dynamodb.ErrCodeItemCollectionSizeLimitExceededException, aerr.Error())
+			case dynamodb.ErrCodeTransactionConflictException:
+				fmt.Println(dynamodb.ErrCodeTransactionConflictException, aerr.Error())
+			case dynamodb.ErrCodeRequestLimitExceeded:
+				fmt.Println(dynamodb.ErrCodeRequestLimitExceeded, aerr.Error())
+			case dynamodb.ErrCodeInternalServerError:
+				fmt.Println(dynamodb.ErrCodeInternalServerError, aerr.Error())
+			default:
+				fmt.Println(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and
+			// Message from an error.
+			fmt.Println(err.Error())
+		}
+		return err
+	}
+
+	Logger.Debugf("Status is updated to %s", status)
+
+	return nil
+}
+
+func (d DynamoDBClient) GetSingleItem(asg, tableName string) (map[string]*dynamodb.AttributeValue, error) {
+	input := &dynamodb.GetItemInput{
+		Key: map[string]*dynamodb.AttributeValue{
+			hashKey: {
+				S: aws.String(asg),
+			},
+		},
+		TableName: aws.String(tableName),
+	}
+
+	result, err := d.Client.GetItem(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case dynamodb.ErrCodeProvisionedThroughputExceededException:
+				fmt.Println(dynamodb.ErrCodeProvisionedThroughputExceededException, aerr.Error())
+			case dynamodb.ErrCodeResourceNotFoundException:
+				fmt.Println(dynamodb.ErrCodeResourceNotFoundException, aerr.Error())
+			case dynamodb.ErrCodeRequestLimitExceeded:
+				fmt.Println(dynamodb.ErrCodeRequestLimitExceeded, aerr.Error())
+			case dynamodb.ErrCodeInternalServerError:
+				fmt.Println(dynamodb.ErrCodeInternalServerError, aerr.Error())
+			default:
+				fmt.Println(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and
+			// Message from an error.
+			fmt.Println(err.Error())
+		}
+		return nil, err
+	}
+
+	return result.Item, err
+}

--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -638,7 +638,7 @@ func (e EC2Client) CreateAutoScalingGroup(name, launch_template_name, healthchec
 }
 
 // GenerateTags creates tag list for autoscaling group
-func (e EC2Client) GenerateTags(tagList []string, asg_name, app, stack, ansibleTags, extraTags, ansibleExtraVars string) []*autoscaling.Tag {
+func (e EC2Client) GenerateTags(tagList []string, asg_name, app, stack, ansibleTags, extraTags, ansibleExtraVars, region string) []*autoscaling.Tag {
 	ret := []*autoscaling.Tag{}
 
 	for _, tagKV := range tagList {
@@ -667,7 +667,7 @@ func (e EC2Client) GenerateTags(tagList []string, asg_name, app, stack, ansibleT
 	//Add stack name
 	ret = append(ret, &autoscaling.Tag{
 		Key:   aws.String("stack"),
-		Value: aws.String(stack),
+		Value: aws.String(fmt.Sprintf("%s_%s", stack, strings.ReplaceAll(region, "-", ""))),
 	})
 
 	//Add ansibleTags

--- a/pkg/builder/metric_builder.go
+++ b/pkg/builder/metric_builder.go
@@ -1,0 +1,47 @@
+package builder
+
+import (
+	Logger "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+)
+
+var (
+	METRIC_YAML_PATH = "metrics.yaml"
+)
+
+type MetricBuilder struct {
+	MetricConfig MetricConfig
+}
+
+type MetricConfig struct {
+	Enabled bool
+	Region  string  `yaml:"region"`
+	Storage Storage `yaml:"storage"`
+}
+
+type Storage struct {
+	Type string `yaml:"type"`
+	Name string `yaml:"name"`
+}
+
+func ParseMetricConfig(disabledMetrics bool) (MetricConfig, error) {
+	if disabledMetrics {
+		return MetricConfig{Enabled: false}, nil
+	}
+
+	metricConfig := MetricConfig{Enabled: true}
+	yamlFile, err := ioutil.ReadFile(METRIC_YAML_PATH)
+	if err != nil {
+		Logger.Errorf("Error reading YAML file: %s\n", err)
+		return metricConfig, err
+	}
+
+	err = yaml.Unmarshal(yamlFile, &metricConfig)
+	if err != nil {
+		Logger.Errorf(err.Error())
+		return metricConfig, err
+	}
+
+	return metricConfig, nil
+}

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -1,0 +1,108 @@
+package collector
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/DevopsArtFactory/goployer/pkg/aws"
+	"github.com/DevopsArtFactory/goployer/pkg/builder"
+	"github.com/DevopsArtFactory/goployer/pkg/tool"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	Logger "github.com/sirupsen/logrus"
+	"time"
+)
+
+type Collector struct {
+	MetricConfig builder.MetricConfig
+	MetricClient aws.MetricClient
+}
+
+func NewCollector(mc builder.MetricConfig, assumeRole string) Collector {
+	return Collector{
+		MetricConfig: mc,
+		MetricClient: aws.BootstrapMetricService(mc.Region, assumeRole),
+	}
+}
+
+func (c Collector) CheckStorage() error {
+	if c.MetricConfig.Storage.Type == "dynamodb" {
+		isExist, err := c.MetricClient.DynamoDBService.CheckTableExists(c.MetricConfig.Storage.Name)
+		if err != nil {
+			return err
+		}
+
+		if isExist {
+			Logger.Infof("you already had a table : %s", c.MetricConfig.Storage.Name)
+		} else {
+			Logger.Infof("you don't have a table : %s", c.MetricConfig.Storage.Name)
+			if err := c.MetricClient.DynamoDBService.CreateTable(c.MetricConfig.Storage.Name); err != nil {
+				return err
+			}
+
+			Logger.Infof("new table is created : %s", c.MetricConfig.Storage.Name)
+		}
+	}
+
+	return nil
+}
+
+func (c Collector) StampDeployment(stack builder.Stack, config builder.Config, tags []*autoscaling.Tag, asg string, status string) error {
+	tagsMap := map[string]string{}
+
+	for _, tag := range tags {
+		tagsMap[*tag.Key] = *tag.Value
+	}
+
+	tagJson, err := json.Marshal(tagsMap)
+	if err != nil {
+		return err
+	}
+	tagString := string(tagJson)
+
+	stackJson, err := json.Marshal(stack)
+	if err != nil {
+		return err
+	}
+	stackString := string(stackJson)
+
+	configJson, err := json.Marshal(config)
+	if err != nil {
+		return err
+	}
+	configString := string(configJson)
+
+	if err := c.MetricClient.DynamoDBService.MakeRecord(stackString, configString, tagString, asg, c.MetricConfig.Storage.Name, status); err != nil {
+		return err
+	}
+
+	return err
+}
+
+func (c Collector) UpdateStatus(asg string, status string, updateFields map[string]string) error {
+	if err := c.MetricClient.DynamoDBService.UpdateRecord("deployment_status", asg, c.MetricConfig.Storage.Name, status, updateFields); err != nil {
+		return err
+	}
+	Logger.Debugf("deployment metric is updated")
+
+	return nil
+}
+
+func (c Collector) GetAdditionalMetric(asg string) (map[string]string, error) {
+	item, err := c.MetricClient.DynamoDBService.GetSingleItem(asg, c.MetricConfig.Storage.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := map[string]string{}
+	for k, v := range item {
+		if k == "deployed_date_kst" {
+			curr := tool.GetKstTimestamp()
+			d, _ := time.Parse(time.RFC3339, *v.S)
+			diff := curr.Sub(d)
+			ret["uptime_second"] = fmt.Sprintf("%f", diff.Seconds())
+			ret["uptime_minute"] = fmt.Sprintf("%f", diff.Minutes())
+			ret["uptime_hour"] = fmt.Sprintf("%f", diff.Hours())
+		}
+	}
+
+	return ret, nil
+}

--- a/pkg/tool/common.go
+++ b/pkg/tool/common.go
@@ -117,3 +117,13 @@ func CheckTimeout(start int64, timeout int64) bool {
 
 	return false
 }
+
+//Get KST Timestamp
+func GetKstTimestamp() time.Time {
+	now := time.Now()
+
+	loc, _ := time.LoadLocation("Asia/Seoul")
+	kst := now.In(loc)
+
+	return kst
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #16 <!-- tracking issues that this PR will close -->

**Description**
Gathering metrics of deployment is important to keep track of histories and those metrics could be used for many different usages. Currently it could be enabled by default, and user could disabled this with `--disable-metrics` argument from command line. 

Currently I added the following information.
- arguments applied from the command
- configurations from manifest file
- stack information user chose for deployment
- Deployment Status
- Deployment / Termination Timestamp
- Uptime for terminated autoscaling group.
