### PR TITLE
Add few features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ commit: format local-build
 	rm -rf ${ARTIFACT_PATH}
 	git add .
 	git commit
-	git push origin $(git branch --show-current)
+	git push origin $(shell git branch --show-current)
 
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,17 @@ format:
 local-build: format
 	go build -o ${ARTIFACT_PATH}/local/${EXECUTE_FILE} main.go
 	mv ${ARTIFACT_PATH}/local/${EXECUTE_FILE} /usr/local/bin
-	rm -rf ${ARTIFACT_PATH}/local/${EXECUTE_FILE}
+	rm -rf ${ARTIFACT_PATH}/local
 
 build: format local-build
 	GOOS=${GOOS} go build -o ${ARTIFACT_PATH}/${EXECUTE_FILE} main.go
+
+commit: format local-build
+	rm -rf ${ARTIFACT_PATH}
+	git add .
+	git commit
+	git push origin $(git branch --show-current)
+
 
 clean:
 	@echo "  >  Cleaning build cache"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ If other autoscaling groups of sample application already existed, for example `
         -  ex) `--extra-tags=key1=value1,key2=value2`
     * `--ansible-extra-vars` : extra variables to be used in ansible. Will be added to tag with `ansible-extra-vars` key.
     * `--override-instance-type` : instance type you want to override when running goployer command.
+    * `--release-notes` : Release notes for deployment.
+    * `--release-notes-base64` : Release notes for deployment encoded with base64
 * If you sepcifies `--ami`, then you must have only one region in a stack or use `--region` option together.
 * You *cannot run goployer from local environment* for security & management issue.
 ```bash

--- a/configs/hello.yaml
+++ b/configs/hello.yaml
@@ -272,13 +272,13 @@ stacks:
           # The ARN of the target that Amazon EC2 Auto Scaling sends notifications to
           # when an instance is in the transition state for the lifecycle hook. The notification
           # target can be either an SQS queue or an SNS topic.
-          #notification_target_arn: arn:aws:sns:ap-northeast-2:816736805842:test
+          #notification_target_arn: arn:aws:sns:ap-northeast-2:xxxxxxxx:test
 
           # The ARN of the IAM role that allows the Auto Scaling group to publish to
           # the specified notification target, for example, an Amazon SNS topic or an
           # Amazon SQS queue.
           # This is required if `notification_target_arn is not empty
-          #role_arn: arn:aws:iam::816736805842:role/test-autoscaling-role
+          #role_arn: arn:aws:iam::xxxxxxxx:role/test-autoscaling-role
 
       # Lifecycle hooks for terminating instances
       #terminate_transition:
@@ -286,8 +286,8 @@ stacks:
       #    heartbeat_timeout: 30
       #    default_result: CONTINUE
       #    notification_metadata: ""
-      #    notification_target_arn: arn:aws:sns:ap-northeast-2:816736805842:test
-      #    role_arn: arn:aws:iam::816736805842:role/test-autoscaling-role
+      #    notification_target_arn: ""
+      #    role_arn: arn:aws:iam::xxxx:role/test-autoscaling-role
 
 
     # list of region

--- a/docs/layouts/partials/page-meta-links.html
+++ b/docs/layouts/partials/page-meta-links.html
@@ -2,7 +2,7 @@
 {{ $gh_repo := ($.Param "github_repo") }}
 {{ if $gh_repo }}
 <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
-{{ $editURL := printf "%s/edit/master/docs/content/%s/%s" $gh_repo ($.Site.Language.Lang) .Path }}
+{{ $editURL := printf "%s/edit/main/docs/content/%s/%s" $gh_repo ($.Site.Language.Lang) .Path }}
 {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}
 <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
 <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>

--- a/pkg/aws/dynamodb.go
+++ b/pkg/aws/dynamodb.go
@@ -116,7 +116,7 @@ func (d DynamoDBClient) CreateTable(tableName string) error {
 	return nil
 }
 
-func (d DynamoDBClient) MakeRecord(stack, config, tags string, asg string, tableName string, status string) error {
+func (d DynamoDBClient) MakeRecord(stack, config, tags string, asg string, tableName string, status string, additionalFields map[string]string) error {
 	input := &dynamodb.PutItemInput{
 		Item: map[string]*dynamodb.AttributeValue{
 			"identifier": {
@@ -139,6 +139,12 @@ func (d DynamoDBClient) MakeRecord(stack, config, tags string, asg string, table
 			},
 		},
 		TableName: aws.String(tableName),
+	}
+
+	if additionalFields != nil && len(additionalFields) > 0 {
+		for k, v := range additionalFields {
+			input.Item[k] = &dynamodb.AttributeValue{S: aws.String(v)}
+		}
 	}
 
 	_, err := d.Client.PutItem(input)

--- a/pkg/builder/metric_builder.go
+++ b/pkg/builder/metric_builder.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	METRIC_YAML_PATH = "metrics.yaml"
+	METRIC_YAML_PATH            = "metrics.yaml"
+	DEFAULT_METRIC_STORAGE_TYPE = "dynamodb"
 )
 
 type MetricBuilder struct {

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -27,11 +27,11 @@ type Deployer struct {
 }
 
 // getCurrentVersion returns current version for current deployment step
-func getCurrentVersion(prev_versions []int) int {
-	if len(prev_versions) == 0 {
+func getCurrentVersion(prevVersions []int) int {
+	if len(prevVersions) == 0 {
 		return 0
 	}
-	return (prev_versions[len(prev_versions)-1] + 1) % 100
+	return (prevVersions[len(prevVersions)-1] + 1) % 100
 }
 
 // Polling for healthcheck
@@ -97,7 +97,9 @@ func (d Deployer) CheckTerminating(client aws.AWSClient, target string) bool {
 		d.Logger.Errorln(err.Error())
 		return false
 	}
-	d.Collector.UpdateStatus(target, "terminated", additionalAttributes)
+	if d.Collector.MetricConfig.Enabled {
+		d.Collector.UpdateStatus(target, "terminated", additionalAttributes)
+	}
 
 	d.Logger.Debug(fmt.Sprintf("Start deleting launch templates in %s", target))
 	if err := client.EC2Service.DeleteLaunchTemplates(target); err != nil {


### PR DESCRIPTION
Add few features
1. `--release-notes`, `--release-notes-base64` added
 : You can specify the release note for the deployment to explain the main features of this release.
 : You cannot use both of these arguments at the same time.

2. Capacity of instances
- If current instance count is bigger than the number of instances in the manifest file, then bigger count will be applied. If you don't want this, then you could disable this feature with `--force-manifest-capacity=true` in the command line.

3. Userdata will be saved in the dynamodb table with base64 encoded.