### PR TITLE
Add polling-interval param for health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If other autoscaling groups of sample application already existed, for example `
     * `--region` : the ID of region to which you want to deploy instances
     * `--ami` : AMI ID
     * `--assume-role` : arn of IAM role you want to assume
-    * `--timeout` : timeout duration of total deployment process in minute. (default: 60 minutes)
+    * `--timeout` : timeout duration of total deployment process (default: 60m)
     * `--slack-off` : whether turning off slack alarm or not. (default: false)
     * `--log-level` : level of Log (debug, info, error)
     * `--extra-tags` : extra tags to set from command line. comma-delimited string(no space between tags)
@@ -43,6 +43,7 @@ If other autoscaling groups of sample application already existed, for example `
     * `--override-instance-type` : instance type you want to override when running goployer command.
     * `--release-notes` : Release notes for deployment.
     * `--release-notes-base64` : Release notes for deployment encoded with base64
+    * `--polling-interval` : Time to interval for polling health check (default 60s) 
 * If you sepcifies `--ami`, then you must have only one region in a stack or use `--region` option together.
 * You *cannot run goployer from local environment* for security & management issue.
 ```bash

--- a/configs/hello.yaml
+++ b/configs/hello.yaml
@@ -45,6 +45,8 @@ tags:
 stacks:
   - stack: artd
 
+    polling_interval: 30s
+
     # account alias
     account: dev
 

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -15,6 +15,8 @@ import (
 var (
 	NO_MANIFEST_EXISTS               = "Manifest file does not exist"
 	DFEAULT_SPOT_ALLOCATION_STRATEGY = "lowest-price"
+	DEFAULT_DEPLOYMENT_TIMEOUT       = 60 * time.Minute
+	DEFAULT_POLLING_INTERVAL         = 60 * time.Second
 	availableBlockTypes              = []string{"io1", "gp2", "st1", "sc1"}
 )
 
@@ -43,7 +45,7 @@ type Config struct {
 	Env                   string
 	Stack                 string
 	AssumeRole            string
-	Timeout               int64
+	Timeout               time.Duration
 	StartTimestamp        int64
 	Region                string
 	Confirm               bool
@@ -56,6 +58,7 @@ type Config struct {
 	ReleaseNotes          string
 	ReleaseNotesBase64    string
 	ForceManifestCapacity bool
+	PollingInterval       time.Duration
 }
 
 type YamlConfig struct {
@@ -114,6 +117,7 @@ type Stack struct {
 	LifecycleCallbacks    LifecycleCallbacks    `yaml:"lifecycle_callbacks"`
 	LifecycleHooks        LifecycleHooks        `yaml:"lifecycle_hooks"`
 	Regions               []RegionConfig        `yaml:"regions"`
+	PollingInterval       time.Duration			`yaml:"polling_interval"`
 }
 
 type LifecycleHooks struct {
@@ -234,11 +238,23 @@ func (b Builder) SetStacks() Builder {
 
 	b.Stacks = Stacks
 
+	var deployStack Stack
+	for _, stack := range Stacks {
+		if b.Config.Stack == stack.Stack {
+			deployStack = stack
+			break
+		}
+	}
+
 	if len(b.Config.Env) == 0 {
-		for _, stack := range Stacks {
-			if b.Config.Stack == stack.Stack {
-				b.Config.Env = stack.Env
-			}
+		b.Config.Env = deployStack.Env
+	}
+
+	if b.Config.PollingInterval == 0 {
+		if deployStack.PollingInterval > 0 {
+			b.Config.PollingInterval = deployStack.PollingInterval
+		} else {
+			b.Config.PollingInterval = DEFAULT_POLLING_INTERVAL
 		}
 	}
 
@@ -415,15 +431,16 @@ func (b Builder) MakeSummary(target_stack string) string {
 ============================================================
 Target Stack Deployment Information
 ============================================================
-name       : %s
-env        : %s
-timeout    : %d
-assume role        : %s
-extra tags        : %s
+name             : %s
+env              : %s
+timeout          : %.0f min
+polling-interval : %.0f sec 
+assume role      : %s
+extra tags       : %s
 ============================================================
 Stack
 ============================================================`
-	summary = append(summary, fmt.Sprintf(formatting, b.AwsConfig.Name, b.Config.Env, b.Config.Timeout, b.Config.AssumeRole, b.Config.ExtraTags))
+	summary = append(summary, fmt.Sprintf(formatting, b.AwsConfig.Name, b.Config.Env, b.Config.Timeout.Minutes(), b.Config.PollingInterval.Seconds(), b.Config.AssumeRole, b.Config.ExtraTags))
 
 	for _, stack := range b.Stacks {
 		if stack.Stack == target_stack {
@@ -499,7 +516,7 @@ func argumentParsing() Config {
 	env := flag.String("env", "", "The environment that is being deployed into.")
 	stack := flag.String("stack", "", "An ordered, comma-delimited list of stacks that should be deployed.")
 	assumeRole := flag.String("assume-role", "", "The Role ARN to assume into")
-	timeout := flag.Int64("timeout", 60, "Time in minutes to wait for deploy to finish before timing out")
+	timeout := flag.Duration("timeout", DEFAULT_DEPLOYMENT_TIMEOUT, "Time to wait for deploy to finish before timing out (default 60m)")
 	region := flag.String("region", "", "The region to deploy into, if undefined, then the deployment will run against all regions for the given environment.")
 	confirm := flag.Bool("confirm", true, "Suppress confirmation prompt")
 	slackOff := flag.Bool("slack-off", false, "Turn off slack alarm")
@@ -511,6 +528,7 @@ func argumentParsing() Config {
 	releaseNotes := flag.String("release-notes", "", "Release note for the current deployment")
 	releaseNotesBase64 := flag.String("release-notes-base64", "", "base64 encoded string of release note for the current deployment")
 	forceManifestCapacity := flag.Bool("force-manifest-capacity", false, "Force-apply the capacity of instances in the manifest file")
+	pollingInterval := flag.Duration("polling-interval", 0, "Time to interval for polling health check (default 60s)")
 
 	flag.Parse()
 
@@ -533,6 +551,7 @@ func argumentParsing() Config {
 		ReleaseNotes:          *releaseNotes,
 		ReleaseNotesBase64:    *releaseNotesBase64,
 		ForceManifestCapacity: *forceManifestCapacity,
+		PollingInterval:       *pollingInterval,
 	}
 
 	return config

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -17,6 +17,7 @@ var (
 	DFEAULT_SPOT_ALLOCATION_STRATEGY = "lowest-price"
 	DEFAULT_DEPLOYMENT_TIMEOUT       = 60 * time.Minute
 	DEFAULT_POLLING_INTERVAL         = 60 * time.Second
+	MIN_POLLING_INTERVAL             = 5 * time.Second
 	availableBlockTypes              = []string{"io1", "gp2", "st1", "sc1"}
 )
 
@@ -419,6 +420,13 @@ func (b Builder) CheckValidation() error {
 
 	if len(b.MetricConfig.Storage.Name) <= 0 {
 		return fmt.Errorf("you do not specify the name of storage for metrics")
+	}
+
+	if b.Config.PollingInterval < MIN_POLLING_INTERVAL {
+		return fmt.Errorf("polling interval cannot be smaller than %.0f sec", MIN_POLLING_INTERVAL.Seconds())
+	}
+	if b.Config.PollingInterval >= b.Config.Timeout {
+		return fmt.Errorf("polling interval should be lower than %.0f min", b.Config.Timeout.Minutes())
 	}
 
 	return nil

--- a/pkg/runner/rurnner.go
+++ b/pkg/runner/rurnner.go
@@ -231,7 +231,7 @@ func doHealthchecking(deployers []deployer.DeployManager, config builder.Config)
 			healthy = true
 		} else {
 			Logger.Info("All stacks are not healthy... Please waiting to be deployed...")
-			time.Sleep(tool.POLLING_SLEEP_TIME)
+			time.Sleep(config.PollingInterval)
 		}
 	}
 }
@@ -275,7 +275,7 @@ func cleanChecking(deployers []deployer.DeployManager, config builder.Config) {
 			done = true
 		} else {
 			Logger.Info("All stacks are not ready to be terminated... Please waiting...")
-			time.Sleep(tool.POLLING_SLEEP_TIME)
+			time.Sleep(config.PollingInterval)
 		}
 	}
 }

--- a/pkg/tool/common.go
+++ b/pkg/tool/common.go
@@ -11,7 +11,6 @@ import (
 var (
 	NO_ERROR_MESSAGE_PASSED = "No Error Message exists"
 	INITIAL_STATUS          = "Not Found"
-	POLLING_SLEEP_TIME      = (60 * time.Second)
 )
 
 // Check if file exists
@@ -105,13 +104,13 @@ func IsStringInArray(s string, arr []string) bool {
 }
 
 //Check timeout
-func CheckTimeout(start int64, timeout int64) bool {
+func CheckTimeout(start int64, timeout time.Duration) bool {
 	now := time.Now().Unix()
-	timeoutSec := timeout * 60
+	timeoutSec := int64(timeout / time.Second)
 
 	//Over timeout
 	if (now - start) > timeoutSec {
-		Logger.Errorf("Timeout has been exceeded : %s minutes", timeout)
+		Logger.Errorf("Timeout has been exceeded : %.0f minutes", timeout.Minutes())
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Fixes: #5  

**Description**
* User can control polling-interval for Health Check next 2ways.
  * Add polling_interval field to stack manifest
  * run goployer with --polling-interval param (It can be override to polling_interval of manifest file)
* Change type of `timeout value` int64 to time.Duration

```bash
INFO[0000] Beginning deployment: hello

============================================================
Target Stack Deployment Information
============================================================
name             : hello
env              : dev
timeout          : 60 min
polling-interval : 30 sec
assume role      :
extra tags       :
```
