### PR TITLE
add request count of target group when terminating asg

### DIFF
--- a/configs/hello.yaml
+++ b/configs/hello.yaml
@@ -71,13 +71,43 @@ stacks:
     # instance_market_options is for spot usage
     # You only can choose spot as market_type.
     # If you want to set customized stop options, then please write spot_options correctly.
-    instance_market_options:
-      market_type: spot
-      spot_options:
-        block_duration_minutes: 180
-        instance_interruption_behavior: terminate # terminate / stop / hibernate
-        max_price: 0.2
-        spot_instance_type: one-time # one-time or persistent
+    #instance_market_options:
+    #  market_type: spot
+    #  spot_options:
+    #    block_duration_minutes: 180
+    #    instance_interruption_behavior: terminate # terminate / stop / hibernate
+    #    max_price: 0.
+    #    spot_instance_type: one-time # one-time or persistent
+
+
+    # MixedInstancesPolicy
+    # You can set autoscaling mixedInstancePolicy to use on demand and spot instances together.
+    # if mixed_instance_policy is set, then `instance_market_options` will be ignored.
+    mixed_instances_policy:
+      enabled: false
+
+      # instance type list to override the instance types in launch template.
+      override_instance_types:
+        - c5.large
+        - c5.xlarge
+
+      # Proportion of on-demand instances.
+      # By default, this value  will be 100 which means no spot instance.
+      on_demand_percentage: 20
+
+      # spot_allocation_strategy means in what strategy you want to allocate spot instances.
+      # options could be either `lowest-price` or `capacity-optimized`.
+      # by default, `low-price` strategy will be applied.
+      spot_allocation_strategy: lowest-price
+
+      # The number of spot instances pool.
+      # This will be set among instance types in `override` fields
+      # This will be valid only if the `spot_allocation_strategy` is low-price.
+      spot_instance_pools: 3
+
+      # Spot price.
+      # By default, on-demand price will be automatically applied.
+      spot_max_price: 0.3
 
     # block_devices is the list of ebs volumes you can use for ec2
     # device_name is required
@@ -116,7 +146,7 @@ stacks:
       - region: ap-northeast-2
 
         # instance type
-        instance_type: m5.large
+        instance_type: t3.medium
 
         # ssh_key for instances
         ssh_key: test-master-key

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -2,3 +2,4 @@ region: ap-northeast-2
 storage:
   type: dynamodb
   name: goployer-metrics
+

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -21,8 +21,9 @@ type AWSClient struct {
 }
 
 type MetricClient struct {
-	Region          string
-	DynamoDBService DynamoDBClient
+	Region            string
+	DynamoDBService   DynamoDBClient
+	CloudWatchService CloudWatchClient
 }
 
 func getAwsSession() *session.Session {
@@ -73,8 +74,9 @@ func BootstrapMetricService(region string, assume_role string) MetricClient {
 
 	//Get all clients
 	client := MetricClient{
-		Region:          region,
-		DynamoDBService: NewDynamoDBClient(aws_session, region, creds),
+		Region:            region,
+		DynamoDBService:   NewDynamoDBClient(aws_session, region, creds),
+		CloudWatchService: NewCloudWatchClient(aws_session, region, creds),
 	}
 
 	return client

--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -943,3 +943,28 @@ func createSingleLifecycleHookSpecification(l builder.LifecycleHookSpecification
 
 	return lhs
 }
+
+// GetTargetGroup returns list of target group ARN of autoscaling group
+func (e EC2Client) GetTargetGroups(asgName string) ([]*string, error) {
+	input := &autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{
+			aws.String(asgName),
+		},
+	}
+
+	result, err := e.AsClient.DescribeAutoScalingGroups(input)
+	if err != nil {
+		return nil, err
+	}
+
+	var ret []*string
+	for _, a := range result.AutoScalingGroups {
+		ret = a.TargetGroupARNs
+	}
+
+	if len(ret) == 0 {
+		return ret, fmt.Errorf("this autoscaling group does not belong to any target group")
+	}
+
+	return ret, nil
+}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -118,7 +118,7 @@ type Stack struct {
 	LifecycleCallbacks    LifecycleCallbacks    `yaml:"lifecycle_callbacks"`
 	LifecycleHooks        LifecycleHooks        `yaml:"lifecycle_hooks"`
 	Regions               []RegionConfig        `yaml:"regions"`
-	PollingInterval       time.Duration			`yaml:"polling_interval"`
+	PollingInterval       time.Duration         `yaml:"polling_interval"`
 }
 
 type LifecycleHooks struct {

--- a/pkg/builder/metric_builder.go
+++ b/pkg/builder/metric_builder.go
@@ -19,11 +19,16 @@ type MetricConfig struct {
 	Enabled bool
 	Region  string  `yaml:"region"`
 	Storage Storage `yaml:"storage"`
+	Metrics Metrics `yaml:"metrics"`
 }
 
 type Storage struct {
 	Type string `yaml:"type"`
 	Name string `yaml:"name"`
+}
+
+type Metrics struct {
+	BaseTimezone string `yaml:"base_timezone"`
 }
 
 func ParseMetricConfig(disabledMetrics bool) (MetricConfig, error) {
@@ -42,6 +47,10 @@ func ParseMetricConfig(disabledMetrics bool) (MetricConfig, error) {
 	if err != nil {
 		Logger.Errorf(err.Error())
 		return metricConfig, err
+	}
+
+	if len(metricConfig.Metrics.BaseTimezone) <= 0 {
+		metricConfig.Metrics.BaseTimezone = "UTC"
 	}
 
 	return metricConfig, nil

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -11,6 +11,11 @@ import (
 	"time"
 )
 
+var (
+	MONTH       = float64(2592000)
+	enableStats = true
+)
+
 type Collector struct {
 	MetricConfig builder.MetricConfig
 	MetricClient aws.MetricClient
@@ -73,15 +78,25 @@ func (c Collector) StampDeployment(stack builder.Stack, config builder.Config, t
 	}
 	configString := string(configJson)
 
-	if err := c.MetricClient.DynamoDBService.MakeRecord(stackString, configString, tagString, asg, c.MetricConfig.Storage.Name, status, additionalFields); err != nil {
+	if err := c.MetricClient.DynamoDBService.MakeRecord(stackString, configString, tagString, asg, c.MetricConfig.Storage.Name, status, c.MetricConfig.Metrics.BaseTimezone, additionalFields); err != nil {
 		return err
 	}
 
 	return err
 }
 
-func (c Collector) UpdateStatus(asg string, status string, updateFields map[string]string) error {
-	if err := c.MetricClient.DynamoDBService.UpdateRecord("deployment_status", asg, c.MetricConfig.Storage.Name, status, updateFields); err != nil {
+func (c Collector) UpdateStatus(asg string, status string, updateFields map[string]interface{}) error {
+	Logger.Debugf("deployment statuses of previous autoscaling groups are started")
+	if err := c.MetricClient.DynamoDBService.UpdateRecord("deployment_status", asg, c.MetricConfig.Storage.Name, status, c.MetricConfig.Metrics.BaseTimezone, updateFields); err != nil {
+		return err
+	}
+	Logger.Debugf("deployment statuses of previous autoscaling groups are updated")
+
+	return nil
+}
+
+func (c Collector) UpdateStatistics(asg string, updateFields map[string]interface{}) error {
+	if err := c.MetricClient.DynamoDBService.UpdateStatistics(asg, c.MetricConfig.Storage.Name, c.MetricConfig.Metrics.BaseTimezone, updateFields); err != nil {
 		return err
 	}
 	Logger.Debugf("deployment metric is updated")
@@ -89,22 +104,52 @@ func (c Collector) UpdateStatus(asg string, status string, updateFields map[stri
 	return nil
 }
 
-func (c Collector) GetAdditionalMetric(asg string) (map[string]string, error) {
+func (c Collector) GetAdditionalMetric(asg string, tgs []*string, logger *Logger.Logger) (map[string]interface{}, error) {
 	item, err := c.MetricClient.DynamoDBService.GetSingleItem(asg, c.MetricConfig.Storage.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	ret := map[string]string{}
+	var baseTimeDuration float64
+	var startDate time.Time
+
+	curr := tool.GetBaseTimeWithTimestamp(c.MetricConfig.Metrics.BaseTimezone)
+	logger.Debugf("current time in timezone %s : %s", c.MetricConfig.Metrics.BaseTimezone, curr)
+
+	ret := map[string]interface{}{}
 	for k, v := range item {
-		if k == "deployed_date_kst" {
-			curr := tool.GetKstTimestamp()
+		if k == "deployed_date" {
 			d, _ := time.Parse(time.RFC3339, *v.S)
 			diff := curr.Sub(d)
 			ret["uptime_second"] = fmt.Sprintf("%f", diff.Seconds())
 			ret["uptime_minute"] = fmt.Sprintf("%f", diff.Minutes())
 			ret["uptime_hour"] = fmt.Sprintf("%f", diff.Hours())
+
+			baseTimeDuration = diff.Seconds()
+			startDate = d
 		}
+	}
+
+	var period int64
+	if len(tgs) > 0 && enableStats {
+		// if baseTimeDuration is over a month which is the maximum duration of cloudwatch
+		// fix the time to one month
+		if baseTimeDuration > MONTH {
+			period = int64(MONTH)
+			startDate = curr.Add(-2592000 * time.Second)
+		}
+
+		startDate = tool.GetBaseStartTime(startDate)
+
+		logger.Debugf("StartDate : %s\n", startDate)
+
+		targetRequest, err := c.MetricClient.CloudWatchService.GetRequestStatistics(tgs, startDate, curr, period, logger)
+		if err != nil {
+			return ret, err
+		}
+
+		ret["stat"] = targetRequest
+		ret["timezone"] = c.MetricConfig.Metrics.BaseTimezone
 	}
 
 	return ret, nil

--- a/pkg/deployer/deploy_manager.go
+++ b/pkg/deployer/deploy_manager.go
@@ -12,4 +12,5 @@ type DeployManager interface {
 	CleanPreviousVersion(config builder.Config) error
 	TriggerLifecycleCallbacks(config builder.Config) error
 	TerminateChecking(config builder.Config) map[string]bool
+	GatherMetrics(config builder.Config) error
 }

--- a/pkg/tool/common.go
+++ b/pkg/tool/common.go
@@ -1,6 +1,7 @@
 package tool
 
 import (
+	"fmt"
 	Logger "github.com/sirupsen/logrus"
 	"log"
 	"os"
@@ -11,6 +12,8 @@ import (
 var (
 	NO_ERROR_MESSAGE_PASSED = "No Error Message exists"
 	INITIAL_STATUS          = "Not Found"
+	DAYTOSEC                = int64(86400)
+	HOURTOSEC               = int64(3600)
 )
 
 // Check if file exists
@@ -117,12 +120,21 @@ func CheckTimeout(start int64, timeout time.Duration) bool {
 	return false
 }
 
-//Get KST Timestamp
-func GetKstTimestamp() time.Time {
+func GetBaseTimeWithTimestamp(timezone string) time.Time {
 	now := time.Now()
 
-	loc, _ := time.LoadLocation("Asia/Seoul")
-	kst := now.In(loc)
+	loc, _ := time.LoadLocation(timezone)
+	return now.In(loc)
+}
 
-	return kst
+func GetBaseTime(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+}
+
+func GetBaseStartTime(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, t.Location()).Add(1 * time.Hour)
+}
+
+func GetTimePrefix(t time.Time) string {
+	return fmt.Sprintf("%d%02d%02d", t.Year(), t.Month(), t.Day())
 }

--- a/server/main.go
+++ b/server/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main()  {
+	
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
**Description**
Add request count of target group when terminating autoscaling group to statistics. Actually it is possible to add more than one autoscaling group to one target group so that this statistic could not be accurate. But AWS users can make as many target group as possible if they need because, as I know, the price of it is ignorable. 

So if we could guide users to match one autoscaling group to one target group then this statistics would be helpful for future usage.

The exact process is...
1. Get target group list  of autoscaling group.
2. Find the time duration how long this autoscaling group exists.
3. Starting with deployed date, get sum of request count for `a day` until terminated date for each target group.
- Statistics example
```
"stat": {
    "targetgroup1": {
      "m2020725": 6,
      "m2020726": 8,
      "total": 14
    },
     "targetgroup2": {
      "m2020725": 1,
      "m2020726": 8,
      "total": 9
    },
  },
```


`This is experimental because we need to ensure this works well. So I would like to test this feature more in our environment. `