### PR TITLE
Hotfix apply assumerole for cloudwatch

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -80,7 +80,7 @@ func BootstrapMetricService(region string, assume_role string) MetricClient {
 	//Get all clients
 	client := MetricClient{
 		Region:            region,
-		DynamoDBService:   NewDynamoDBClient(aws_session, region, creds),
+		DynamoDBService:   NewDynamoDBClient(aws_session, region, nil),
 		CloudWatchService: NewCloudWatchClient(aws_session, region, creds),
 	}
 

--- a/pkg/runner/rurnner.go
+++ b/pkg/runner/rurnner.go
@@ -127,7 +127,7 @@ func NewRunner(newBuilder builder.Builder) (Runner, error) {
 	return Runner{
 		Logger:    Logger.New(),
 		Builder:   newBuilder,
-		Collector: collector.NewCollector(newBuilder.MetricConfig, ""),
+		Collector: collector.NewCollector(newBuilder.MetricConfig, newBuilder.Config.AssumeRole),
 		Slacker:   tool.NewSlackClient(newBuilder.Config.SlackOff),
 	}, nil
 }


### PR DESCRIPTION
Use assume role for aws cloudwatch api because we need to gather information about the target group in assumed account.

MetricClient in Collector has all AWS Client for gathering metrics and I  manually use `nil` to dynamodb client.
```
        //Get all clients
	client := MetricClient{
		Region:            region,
		DynamoDBService:   NewDynamoDBClient(aws_session, region, nil),
		CloudWatchService: NewCloudWatchClient(aws_session, region, creds),
	}
```