### PR TITLE
add no target group deployment

### DIFF
--- a/configs/hello.yaml
+++ b/configs/hello.yaml
@@ -186,6 +186,7 @@ stacks:
         # The target group in the healthcheck_target_group should be included here.
         target_groups:
           - hello-artdapne2-ext
+
   - stack: artp
 
     # account alias

--- a/hack/apitest.sh
+++ b/hack/apitest.sh
@@ -5,7 +5,7 @@ BUILD_DIR="build"
 TEST_DIR="test"
 URL="https://hello.devops-art-factory.com"
 
-stacks=("artd" "artd-spot" "artd-mixed")
+stacks=("artd" "artd-spot" "artd-mixed" "artd-without-targetgroup")
 
 if [[ ! -d $BUILD_DIR ]]; then
     echo "creating new directory [ $BUILD_DIR ]"
@@ -24,7 +24,7 @@ fi
 
 # api test
 for stack in "${stacks[@]}"; do
-    ./$BUILD_DIR/goployer --manifest=$TEST_DIR/test_manifest.yaml --stack=$stack --slack-off=true --log-level=debug --region=ap-northeast-2 --polling-interval=30s
+    ./$BUILD_DIR/goployer --manifest=$TEST_DIR/test_manifest.yaml --stack=$stack --slack-off=true --log-level=debug --region=ap-northeast-2 --polling-interval=20s
     if [[ $? -eq 0 ]]; then
         echo "$stack is deployed"
         for ((i=1;i<=10;i++)); do

--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -550,7 +550,8 @@ func (e EC2Client) CreateAutoScalingGroup(name, launch_template_name, healthchec
 	loadbalancers, target_group_arns, termination_policies, availability_zones []*string,
 	tags []*(autoscaling.Tag),
 	subnets []string,
-	mixedInstancePolicy builder.MixedInstancesPolicy, hooks []*autoscaling.LifecycleHookSpecification) bool {
+	mixedInstancePolicy builder.MixedInstancesPolicy,
+	hooks []*autoscaling.LifecycleHookSpecification) bool {
 
 	lt := autoscaling.LaunchTemplateSpecification{
 		LaunchTemplateName: aws.String(launch_template_name),
@@ -569,11 +570,11 @@ func (e EC2Client) CreateAutoScalingGroup(name, launch_template_name, healthchec
 		VPCZoneIdentifier:      aws.String(strings.Join(subnets, ",")),
 	}
 
-	if *loadbalancers[0] != "" {
+	if len(loadbalancers) > 0 {
 		input.LoadBalancerNames = loadbalancers
 	}
 
-	if *target_group_arns[0] != "" {
+	if len(target_group_arns) > 0 {
 		input.TargetGroupARNs = target_group_arns
 	}
 
@@ -946,10 +947,6 @@ func (e EC2Client) GetTargetGroups(asgName string) ([]*string, error) {
 	var ret []*string
 	for _, a := range result.AutoScalingGroups {
 		ret = a.TargetGroupARNs
-	}
-
-	if len(ret) == 0 {
-		return ret, fmt.Errorf("this autoscaling group does not belong to any target group")
 	}
 
 	return ret, nil

--- a/pkg/aws/elbv2.go
+++ b/pkg/aws/elbv2.go
@@ -39,9 +39,9 @@ func getElbClientFn(session *session.Session, region string, creds *credentials.
 }
 
 // GetTargetGroupARNs returns arn list of target groups
-func (e ELBV2Client) GetTargetGroupARNs(target_groups []string) []*string {
+func (e ELBV2Client) GetTargetGroupARNs(target_groups []string) ([]*string, error) {
 	if len(target_groups) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	input := &elbv2.DescribeTargetGroupsInput{
@@ -50,21 +50,7 @@ func (e ELBV2Client) GetTargetGroupARNs(target_groups []string) []*string {
 
 	result, err := e.Client.DescribeTargetGroups(input)
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case elbv2.ErrCodeLoadBalancerNotFoundException:
-				Logger.Errorln(elbv2.ErrCodeLoadBalancerNotFoundException, aerr.Error())
-			case elbv2.ErrCodeTargetGroupNotFoundException:
-				Logger.Errorln(elbv2.ErrCodeTargetGroupNotFoundException, aerr.Error())
-			default:
-				Logger.Errorln(aerr.Error())
-			}
-		} else {
-			// Print the error, cast err to awserr.Error to get the Code and
-			// Message from an error.
-			Logger.Errorln(err.Error())
-		}
-		os.Exit(1)
+		return nil, err
 	}
 
 	ret := []*string{}
@@ -72,7 +58,7 @@ func (e ELBV2Client) GetTargetGroupARNs(target_groups []string) []*string {
 		ret = append(ret, group.TargetGroupArn)
 	}
 
-	return ret
+	return ret, nil
 }
 
 // GetHostInTarget gets host instance

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -278,14 +278,27 @@ func (b Builder) CheckValidation() error {
 		}
 
 		for _, region := range stack.Regions {
-			//Check ami id
+			// Check ami id
 			if len(target_ami) == 0 && len(region.AmiId) == 0 {
 				return fmt.Errorf("you have to specify at least one ami id")
 			}
 
-			//Check instance type
+			// Check instance type
 			if len(region.InstanceType) == 0 {
 				return fmt.Errorf("you have to specify the instance type")
+			}
+
+			// Check target group
+			if len(region.TargetGroups) == 0 && region.HealthcheckTargetGroup != "" {
+				return fmt.Errorf("you have to add healthcheck_target_group to target_groups")
+			}
+
+			if len(region.TargetGroups) > 0 && region.HealthcheckTargetGroup == "" {
+				return fmt.Errorf("you have to choose one target group as healthcheck_target_group")
+			}
+
+			if len(region.TargetGroups) > 0 && region.HealthcheckTargetGroup != "" && !tool.IsStringInArray(region.HealthcheckTargetGroup, region.TargetGroups){
+				return fmt.Errorf("you have to choose the healthcheck_target_group from the target_groups")
 			}
 		}
 

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -230,6 +230,24 @@ func TestCheckValidationStack(t *testing.T) {
 	}
 	b.Stacks[0].Regions[0].InstanceType = "t3.large"
 
+
+	b.Stacks[0].Regions[0].HealthcheckTargetGroup = "test-tg"
+	if err := b.CheckValidation(); err == nil || err.Error() != "you have to add healthcheck_target_group to target_groups" {
+		t.Errorf("validation failed: target groups missing")
+	}
+	b.Stacks[0].Regions[0].HealthcheckTargetGroup = ""
+
+	b.Stacks[0].Regions[0].TargetGroups = []string{"test-tg"}
+	if err := b.CheckValidation(); err == nil || err.Error() != "you have to choose one target group as healthcheck_target_group" {
+		t.Errorf("validation failed: healthcheck target group missing")
+	}
+
+	b.Stacks[0].Regions[0].HealthcheckTargetGroup = "test-tg2"
+	if err := b.CheckValidation(); err == nil || err.Error() != "you have to choose the healthcheck_target_group from the target_groups" {
+		t.Errorf("validation failed: wrong healthcheck target group")
+	}
+	b.Stacks[0].Regions[0].HealthcheckTargetGroup = "test-tg"
+
 	b.Stacks[0].MixedInstancesPolicy = MixedInstancesPolicy{
 		Enabled:                true,
 		SpotAllocationStrategy: "capacity-optimized",

--- a/pkg/deployer/deploy_manager.go
+++ b/pkg/deployer/deploy_manager.go
@@ -6,7 +6,7 @@ import (
 
 type DeployManager interface {
 	GetStackName() string
-	Deploy(config builder.Config)
+	Deploy(config builder.Config) error
 	HealthChecking(config builder.Config) map[string]bool
 	FinishAdditionalWork(config builder.Config) error
 	CleanPreviousVersion(config builder.Config) error

--- a/test/test_manifest.yaml
+++ b/test/test_manifest.yaml
@@ -43,7 +43,7 @@ tags:
 
 stacks:
   - stack: artd
-    polling_interval: 30s
+    polling_interval: 20s
     account: dev
     env: dev
     assume_role: ""
@@ -51,13 +51,6 @@ stacks:
     iam_instance_profile: 'app-hello-profile'
     ansible_tags: all
     ebs_optimized: true
-    #instance_market_options:
-    #  market_type: spot
-    #  spot_options:
-    #    block_duration_minutes: 180
-    #    instance_interruption_behavior: terminate # terminate / stop / hibernate
-    #    max_price: 0.
-    #    spot_instance_type: one-time # one-time or persistent
     mixed_instances_policy:
       enabled: false
       override_instance_types:
@@ -105,7 +98,7 @@ stacks:
           - hello-artdapne2-ext
 
   - stack: artd-spot
-    polling_interval: 30s
+    polling_interval: 20s
     account: dev
     env: dev
     assume_role: ""
@@ -157,7 +150,7 @@ stacks:
           - hello-artdapne2-ext
 
   - stack: artd-mixed
-    polling_interval: 30s
+    polling_interval: 20s
     account: dev
     env: dev
     assume_role: ""
@@ -169,10 +162,9 @@ stacks:
       enabled: true
       override_instance_types:
         - c5.large
-        - c5.xlarge
       on_demand_percentage: 20
       spot_allocation_strategy: lowest-price
-      spot_instance_pools: 3
+      spot_instance_pools: 1
       spot_max_price: 0.3
 
     block_devices:
@@ -210,3 +202,41 @@ stacks:
           - ap-northeast-2c
         target_groups:
           - hello-artdapne2-ext
+
+  - stack: artd-without-targetgroup
+    polling_interval: 20s
+    account: dev
+    env: dev
+    assume_role: ""
+    replacement_type: BlueGreen
+    iam_instance_profile: 'app-hello-profile'
+    ansible_tags: all
+    ebs_optimized: true
+
+    # capacity
+    capacity:
+      min: 1
+      max: 2
+      desired: 1
+
+    autoscaling: *autoscaling_policy
+    alarms: *autoscaling_alarms
+
+    lifecycle_callbacks:
+      pre_terminate_past_cluster:
+        - service hello stop
+
+    regions:
+      - region: ap-northeast-2
+        instance_type: t3.medium
+        ssh_key: test-master-key
+        ami_id: ami-01288945bd24ed49a
+        use_public_subnets: true
+        vpc: vpc-artd_apnortheast2
+        security_groups:
+          - hello-artd_apnortheast2
+          - default-artd_apnortheast2
+        availability_zones:
+          - ap-northeast-2a
+          - ap-northeast-2b
+          - ap-northeast-2c


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #54  <!-- tracking issues that this PR will close -->

**Description**
If there is no target group specified, then skip healthcheck. This feature helps when a user wants to deploy autoscaling only without attaching target group such as bastion host.

I added few health check logic.
1. healthcheck_target_group cannot be empty if target_groups are not empty
2. target_groups cannot be empty if healthcheck_target_group is not empty
3. target_groups should contain healthcheck_target_group if neither of them is empty

**User facing changes (remove if N/A)**
User could deploy without target group.