### PR TITLE
add classic LB support

### DIFF
--- a/examples/manifests/healthcheck-loadbalancer-example.yaml
+++ b/examples/manifests/healthcheck-loadbalancer-example.yaml
@@ -1,0 +1,87 @@
+---
+name: hello
+userdata:
+  type: local
+  path: examples/scripts/userdata.sh
+
+autoscaling: &autoscaling_policy
+  - name: scale_up
+    adjustment_type: ChangeInCapacity
+    scaling_adjustment: 1
+    cooldown: 60
+  - name: scale_down
+    adjustment_type: ChangeInCapacity
+    scaling_adjustment: -1
+    cooldown: 180
+
+alarms: &autoscaling_alarms
+  - name: scale_up_on_util
+    namespace: AWS/EC2
+    metric: CPUUtilization
+    statistic: Average
+    comparison: GreaterThanOrEqualToThreshold
+    threshold: 50
+    period: 120
+    evaluation_periods: 2
+    alarm_actions:
+      - scale_up
+  - name: scale_down_on_util
+    namespace: AWS/EC2
+    metric: CPUUtilization
+    statistic: Average
+    comparison: LessThanOrEqualToThreshold
+    threshold: 30
+    period: 300
+    evaluation_periods: 3
+    alarm_actions:
+      - scale_down
+
+tags:
+  - project=test
+  - app=hello
+  - repo=hello-deploy
+
+stacks:
+  - stack: artd
+    polling_interval: 30s
+    account: dev
+    env: dev
+    assume_role: ""
+    replacement_type: BlueGreen
+    iam_instance_profile: 'app-hello-profile'
+    ansible_tags: all
+    ebs_optimized: true
+    block_devices:
+      - device_name: /dev/xvda
+        volume_size: 100
+        volume_type: "gp2"
+      - device_name: /dev/xvdb
+        volume_type: "st1"
+        volume_size: 500
+    capacity:
+      min: 1
+      max: 2
+      desired: 1
+    autoscaling: *autoscaling_policy
+    alarms: *autoscaling_alarms
+    lifecycle_callbacks:
+      pre_terminate_past_cluster:
+        - service hello stop
+
+    regions:
+      - region: ap-northeast-2
+        instance_type: t3.medium
+        ssh_key: test-master-key
+        ami_id: ami-01288945bd24ed49a
+        use_public_subnets: true
+        vpc: vpc-artd_apnortheast2
+        security_groups:
+          - hello-artd_apnortheast2
+          - default-artd_apnortheast2
+
+        # This should be a classic load balancer
+        healthcheck_load_balancer: test
+        availability_zones:
+          - ap-northeast-2a
+          - ap-northeast-2b
+          - ap-northeast-2c

--- a/hack/apitest.sh
+++ b/hack/apitest.sh
@@ -5,7 +5,7 @@ BUILD_DIR="build"
 TEST_DIR="test"
 URL="https://hello.devops-art-factory.com"
 
-stacks=("artd" "artd-spot" "artd-mixed" "artd-without-targetgroup")
+stacks=("artd" "artd-spot" "artd-mixed" "artd-without-targetgroup" "artd-with-exact-values" "artd-with-classic-lb")
 
 if [[ ! -d $BUILD_DIR ]]; then
     echo "creating new directory [ $BUILD_DIR ]"
@@ -25,6 +25,7 @@ fi
 # api test
 lastStack=""
 for stack in "${stacks[@]}"; do
+    echo "stack: $stack"
     ./$BUILD_DIR/goployer deploy --manifest=$TEST_DIR/test_manifest.yaml --stack=$stack --slack-off=true --log-level=debug --region=ap-northeast-2 --polling-interval=20s
     if [[ $? -eq 0 ]]; then
         echo "$stack is deployed"

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -15,7 +15,8 @@ var (
 type AWSClient struct {
 	Region            string
 	EC2Service        EC2Client
-	ELBService        ELBV2Client
+	ELBV2Service      ELBV2Client
+	ELBService        ELBClient
 	CloudWatchService CloudWatchClient
 	SSMService        SSMClient
 }
@@ -61,7 +62,8 @@ func BootstrapServices(region string, assume_role string) AWSClient {
 	client := AWSClient{
 		Region:            region,
 		EC2Service:        NewEC2Client(aws_session, region, creds),
-		ELBService:        NewELBV2Client(aws_session, region, creds),
+		ELBV2Service:      NewELBV2Client(aws_session, region, creds),
+		ELBService:        NewELBClient(aws_session, region, creds),
 		CloudWatchService: NewCloudWatchClient(aws_session, region, creds),
 		SSMService:        NewSSMClient(aws_session, region, creds),
 	}

--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -541,7 +541,7 @@ func (e EC2Client) CreateAutoScalingGroup(name, launch_template_name, healthchec
 	tags []*(autoscaling.Tag),
 	subnets []string,
 	mixedInstancePolicy builder.MixedInstancesPolicy,
-	hooks []*autoscaling.LifecycleHookSpecification) bool {
+	hooks []*autoscaling.LifecycleHookSpecification) (bool, error) {
 
 	lt := autoscaling.LaunchTemplateSpecification{
 		LaunchTemplateName: aws.String(launch_template_name),
@@ -602,30 +602,11 @@ func (e EC2Client) CreateAutoScalingGroup(name, launch_template_name, healthchec
 
 	_, err := e.AsClient.CreateAutoScalingGroup(input)
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case autoscaling.ErrCodeAlreadyExistsFault:
-				Logger.Errorln(autoscaling.ErrCodeAlreadyExistsFault, aerr.Error())
-			case autoscaling.ErrCodeLimitExceededFault:
-				Logger.Errorln(autoscaling.ErrCodeLimitExceededFault, aerr.Error())
-			case autoscaling.ErrCodeResourceContentionFault:
-				Logger.Errorln(autoscaling.ErrCodeResourceContentionFault, aerr.Error())
-			case autoscaling.ErrCodeServiceLinkedRoleFailure:
-				Logger.Errorln(autoscaling.ErrCodeServiceLinkedRoleFailure, aerr.Error())
-			default:
-				Logger.Errorln(aerr.Error())
-			}
-		} else {
-			// Print the error, cast err to awserr.Error to get the Code and
-			// Message from an error.
-			Logger.Errorln(err.Error())
-		}
-		return false
+		return false, err
 	}
 
 	Logger.Info("Successfully create new autoscaling group : ", name)
-
-	return true
+	return true, nil
 }
 
 // GenerateTags creates tag list for autoscaling group

--- a/pkg/aws/elb.go
+++ b/pkg/aws/elb.go
@@ -1,0 +1,69 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/DevopsArtFactory/goployer/pkg/tool"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/elb"
+	Logger "github.com/sirupsen/logrus"
+)
+
+type ELBClient struct {
+	Client *elb.ELB
+}
+
+type HealthcheckELBHost struct {
+	InstanceId     string
+	LifecycleState string
+	TargetStatus   string
+	HealthStatus   string
+	Healthy        bool
+}
+
+func NewELBClient(session *session.Session, region string, creds *credentials.Credentials) ELBClient {
+	return ELBClient{
+		Client: getELBClientFn(session, region, creds),
+	}
+}
+
+func getELBClientFn(session *session.Session, region string, creds *credentials.Credentials) *elb.ELB {
+	if creds == nil {
+		return elb.New(session, &aws.Config{Region: aws.String(region)})
+	}
+	return elb.New(session, &aws.Config{Region: aws.String(region), Credentials: creds})
+}
+
+// GetHostInELB returns instances in ELB
+func (e ELBClient) GetHealthyHostInELB(group *autoscaling.Group, elbName string) ([]HealthcheckHost, error) {
+	Logger.Debug(fmt.Sprintf("[Checking healthy host count] Autoscaling Group: %s", *group.AutoScalingGroupName))
+
+	input := &elb.DescribeInstanceHealthInput{
+		LoadBalancerName: aws.String(elbName),
+	}
+
+	result, err := e.Client.DescribeInstanceHealth(input)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := []HealthcheckHost{}
+	targetInstances := []string{}
+	for _, instance := range group.Instances {
+		targetInstances = append(targetInstances, *instance.InstanceId)
+	}
+	for _, instance := range result.InstanceStates {
+		if tool.IsStringInArray(*instance.InstanceId, targetInstances) {
+			ret = append(ret, HealthcheckHost{
+				InstanceId:     *instance.InstanceId,
+				LifecycleState: *instance.State,
+				Healthy:        *instance.State == "InService",
+			})
+		}
+	}
+
+	return ret, nil
+}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -278,16 +278,23 @@ func (b Builder) CheckValidation() error {
 			}
 
 			// Check target group
-			if len(region.TargetGroups) == 0 && region.HealthcheckTargetGroup != "" {
-				return fmt.Errorf("you have to add healthcheck_target_group to target_groups")
-			}
-
 			if len(region.TargetGroups) > 0 && region.HealthcheckTargetGroup == "" {
 				return fmt.Errorf("you have to choose one target group as healthcheck_target_group")
 			}
 
-			if len(region.TargetGroups) > 0 && region.HealthcheckTargetGroup != "" && !tool.IsStringInArray(region.HealthcheckTargetGroup, region.TargetGroups) {
-				return fmt.Errorf("you have to choose the healthcheck_target_group from the target_groups")
+			// Check load balancer
+			if len(region.LoadBalancers) > 0 && region.HealthcheckLB == "" {
+				return fmt.Errorf("you have to choose one load balancer as healthcheck_load_balancer")
+			}
+
+			// Check load balancer
+			if region.HealthcheckLB != "" && len(region.TargetGroups) > 0 {
+				return fmt.Errorf("you cannot use healthcheck_load_balancer with target_groups")
+			}
+
+			// Check load balancer and target group
+			if region.HealthcheckLB != "" && region.HealthcheckTargetGroup != "" {
+				return fmt.Errorf("you cannot use healthcheck_target_group and healthcheck_load_balancer at the same time")
 			}
 		}
 

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -230,22 +230,30 @@ func TestCheckValidationStack(t *testing.T) {
 	}
 	b.Stacks[0].Regions[0].InstanceType = "t3.large"
 
-	b.Stacks[0].Regions[0].HealthcheckTargetGroup = "test-tg"
-	if err := b.CheckValidation(); err == nil || err.Error() != "you have to add healthcheck_target_group to target_groups" {
-		t.Errorf("validation failed: target groups missing")
-	}
 	b.Stacks[0].Regions[0].HealthcheckTargetGroup = ""
-
 	b.Stacks[0].Regions[0].TargetGroups = []string{"test-tg"}
 	if err := b.CheckValidation(); err == nil || err.Error() != "you have to choose one target group as healthcheck_target_group" {
 		t.Errorf("validation failed: healthcheck target group missing")
 	}
-
-	b.Stacks[0].Regions[0].HealthcheckTargetGroup = "test-tg2"
-	if err := b.CheckValidation(); err == nil || err.Error() != "you have to choose the healthcheck_target_group from the target_groups" {
-		t.Errorf("validation failed: wrong healthcheck target group")
-	}
 	b.Stacks[0].Regions[0].HealthcheckTargetGroup = "test-tg"
+
+	b.Stacks[0].Regions[0].HealthcheckLB = ""
+	b.Stacks[0].Regions[0].LoadBalancers = []string{"test-lb"}
+	if err := b.CheckValidation(); err == nil || err.Error() != "you have to choose one load balancer as healthcheck_load_balancer" {
+		t.Errorf("validation failed: healthcheck load balancer missing")
+	}
+	b.Stacks[0].Regions[0].HealthcheckLB = "test-lb"
+
+	if err := b.CheckValidation(); err == nil || err.Error() != "you cannot use healthcheck_load_balancer with target_groups" {
+		t.Errorf("validation failed: mixing healthcheck load balancer and target groups")
+	}
+	b.Stacks[0].Regions[0].TargetGroups = nil
+
+	if err := b.CheckValidation(); err == nil || err.Error() != "you cannot use healthcheck_target_group and healthcheck_load_balancer at the same time" {
+		t.Errorf("validation failed: mixing healthcheck target group and healthcheck load balancer")
+	}
+	b.Stacks[0].Regions[0].HealthcheckLB = ""
+	b.Stacks[0].Regions[0].LoadBalancers = nil
 
 	b.Stacks[0].MixedInstancesPolicy = MixedInstancesPolicy{
 		Enabled:                true,

--- a/test/test_manifest.yaml
+++ b/test/test_manifest.yaml
@@ -236,7 +236,81 @@ stacks:
         security_groups:
           - hello-artd_apnortheast2
           - default-artd_apnortheast2
+
+  - stack: artd-with-exact-values
+    polling_interval: 20s
+    account: dev
+    env: dev
+    assume_role: ""
+    replacement_type: BlueGreen
+    iam_instance_profile:
+    ansible_tags: all
+    ebs_optimized: true
+
+    # capacity
+    capacity:
+      min: 1
+      max: 2
+      desired: 1
+
+    autoscaling: *autoscaling_policy
+    alarms: *autoscaling_alarms
+
+    lifecycle_callbacks:
+      pre_terminate_past_cluster:
+        - service hello stop
+
+    regions:
+      - region: ap-northeast-2
+        instance_type: t3.medium
+        ssh_key: test-master-key
+        ami_id: ami-01288945bd24ed49a
+        use_public_subnets: true
+        vpc: vpc-05be14885b028018d
+        security_groups:
+          - hello-artd_apnortheast2
+          - default-artd_apnortheast2
         availability_zones:
           - ap-northeast-2a
           - ap-northeast-2b
           - ap-northeast-2c
+
+  - stack: artd-with-classic-lb
+    polling_interval: 20s
+    account: dev
+    env: dev
+    assume_role: ""
+    replacement_type: BlueGreen
+    iam_instance_profile:
+    ansible_tags: all
+    ebs_optimized: true
+
+    # capacity
+    capacity:
+      min: 1
+      max: 2
+      desired: 1
+
+    autoscaling: *autoscaling_policy
+    alarms: *autoscaling_alarms
+
+    lifecycle_callbacks:
+      pre_terminate_past_cluster:
+        - service hello stop
+
+    regions:
+      - region: ap-northeast-2
+        instance_type: t3.medium
+        ssh_key: test-master-key
+        ami_id: ami-01288945bd24ed49a
+        use_public_subnets: true
+        vpc: vpc-05be14885b028018d
+        healthcheck_load_balancer: test
+        security_groups:
+          - hello-artd_apnortheast2
+          - default-artd_apnortheast2
+        availability_zones:
+          - ap-northeast-2a
+          - ap-northeast-2b
+          - ap-northeast-2c
+


### PR DESCRIPTION
Add classic LB support

If a user wants to deploy to classic load balancer, he/she could use `healthcheck_load_balancer` not `healthcheck_target_group`