### PR TITLE
goployer apply goroutine for deploy/delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ out
 build
 venv
 .DS_Store
+configs

--- a/configs/hello.yaml
+++ b/configs/hello.yaml
@@ -2,7 +2,7 @@
 name: hello
 userdata:
   type: local
-  path: scripts/userdata.sh
+  path: examples/scripts/userdata.sh
 
 autoscaling: &autoscaling_policy
   - name: scale_in
@@ -188,3 +188,44 @@ stacks:
         # The target group in the healthcheck_target_group should be included here.
         target_groups:
           - hello-artdapne2-ext
+
+  - stack: test
+    polling_interval: 20s
+    account: dev
+    env: stage
+    assume_role: ""
+    replacement_type: BlueGreen
+    iam_instance_profile:
+    tags:
+      - test-stack=artd-with-classic-lb
+    ebs_optimized: true
+
+    # capacity
+    capacity:
+      min: 1
+      max: 2
+      desired: 1
+
+    autoscaling: *autoscaling_policy
+    alarms: *autoscaling_alarms
+
+    lifecycle_callbacks:
+      pre_terminate_past_cluster:
+        - service hello stop
+
+    regions:
+      - region: ap-northeast-2
+        instance_type: t3.medium
+        ssh_key: test-master-key
+        ami_id: ami-01288945bd24ed49a
+        use_public_subnets: true
+        vpc: vpc-05be14885b028018d
+        healthcheck_load_balancer: test
+        security_groups:
+          - hello-artd_apnortheast2
+          - default-artd_apnortheast2
+        availability_zones:
+          - ap-northeast-2a
+          - ap-northeast-2b
+          - ap-northeast-2c
+

--- a/hack/apitest.sh
+++ b/hack/apitest.sh
@@ -41,12 +41,17 @@ for stack in "${stacks[@]}"; do
         echo "healthcheck is done"
     fi
     lastStack=$stack
-    sleep 30
+    sleep 15
 done
+
+# Multistack
+echo "test with multistack"
+./$BUILD_DIR/goployer deploy --auto-apply --manifest=$TEST_DIR/test_manifest.yaml --slack-off=true --log-level=debug --region=ap-northeast-2 --polling-interval=20s
+
 echo "API deployment test is done"
 
 echo  "delete test autoscaling group"
-./$BUILD_DIR/goployer delete --auto-apply --manifest=$TEST_DIR/test_manifest.yaml --stack=$lastStack --slack-off=true --log-level=debug --region=ap-northeast-2 --polling-interval=20s
+./$BUILD_DIR/goployer delete --auto-apply --manifest=$TEST_DIR/test_manifest.yaml --slack-off=true --log-level=debug --region=ap-northeast-2 --polling-interval=20s
 
 rm -rf $BUILD_DIR
 

--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -86,33 +86,17 @@ func (e EC2Client) DeleteLaunchTemplates(asg_name string) error {
 // Delete Autoscaling group Set
 // 1. Autoscaling Group
 // 2. Luanch Configurations in asg
-func (e EC2Client) DeleteAutoscalingSet(asg_name string) bool {
+func (e EC2Client) DeleteAutoscalingSet(asg_name string) error {
 	input := &autoscaling.DeleteAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String(asg_name),
 	}
 
 	_, err := e.AsClient.DeleteAutoScalingGroup(input)
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case autoscaling.ErrCodeScalingActivityInProgressFault:
-				Logger.Errorln(autoscaling.ErrCodeScalingActivityInProgressFault, aerr.Error())
-			case autoscaling.ErrCodeResourceInUseFault:
-				Logger.Errorln(autoscaling.ErrCodeResourceInUseFault, aerr.Error())
-			case autoscaling.ErrCodeResourceContentionFault:
-				Logger.Errorln(autoscaling.ErrCodeResourceContentionFault, aerr.Error())
-			default:
-				Logger.Errorln(aerr.Error())
-			}
-		} else {
-			// Print the error, cast err to awserr.Error to get the Code and
-			// Message from an error.
-			Logger.Errorln(err.Error())
-		}
-		return false
+		return err
 	}
 
-	return true
+	return nil
 }
 
 // Get All matching autoscaling groups with aws prefix
@@ -801,8 +785,6 @@ func (e EC2Client) UpdateAutoScalingGroup(asg string, min, max, desired, retry i
 		MinSize:              aws.Int64(min),
 		DesiredCapacity:      aws.Int64(desired),
 	}
-
-	Logger.Info(input)
 
 	_, err := e.AsClient.UpdateAutoScalingGroup(input)
 	if err != nil {

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -135,27 +135,22 @@ func (b Builder) SetStacks(stacks []schemas.Stack) Builder {
 		}
 	}
 
-	var deployStack schemas.Stack
-	for _, stack := range stacks {
-		if b.Config.Stack == stack.Stack {
-			deployStack = stack
-			break
+	//var deployStack *schemas.Stack
+	for i, _ := range stacks {
+		if len(b.Config.Env) > 0 {
+			stacks[i].Env = b.Config.Env
+		}
+		//if b.Config.Stack == stack.Stack {
+		//	deployStack = &stack
+		//	break
+		//}
+
+		if b.Config.PollingInterval > 0 {
+			stacks[i].PollingInterval = b.Config.PollingInterval
 		}
 	}
 
 	b.Stacks = stacks
-
-	if len(b.Config.Env) == 0 {
-		b.Config.Env = deployStack.Env
-	}
-
-	if b.Config.PollingInterval == 0 {
-		if deployStack.PollingInterval > 0 {
-			b.Config.PollingInterval = deployStack.PollingInterval
-		} else {
-			b.Config.PollingInterval = DEFAULT_POLLING_INTERVAL
-		}
-	}
 
 	return b
 }
@@ -166,11 +161,6 @@ func (b Builder) CheckValidation() error {
 	target_region := b.Config.Region
 
 	// check configurations
-	// check stack
-	if len(b.Config.Stack) == 0 {
-		return fmt.Errorf("you should choose at least one stack")
-	}
-
 	if len(b.AwsConfig.Tags) > 0 && HasProhibited(b.AwsConfig.Tags) {
 		return fmt.Errorf("you cannot use prohibited tags : %s", strings.Join(prohibitedTags, ","))
 	}

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -13,15 +13,12 @@ import (
 func TestCheckValidationConfig(t *testing.T) {
 	b := Builder{
 		Config: Config{
+			Stack: "artd",
 			Manifest: "config/hello.yaml",
 			Timeout:  DEFAULT_DEPLOYMENT_TIMEOUT,
 		},
 	}
 
-	if err := b.CheckValidation(); err == nil || err.Error() != "you should choose at least one stack" {
-		t.Errorf("validation failed: stack")
-	}
-	b.Config.Stack = "artd"
 
 	b.Config.Ami = "ami-test"
 	if err := b.CheckValidation(); err == nil || fmt.Sprintf("%s", err.Error()) != fmt.Sprintf("ami id cannot be used in different regions : %s", b.Config.Ami) {

--- a/pkg/deployer/deploy_manager.go
+++ b/pkg/deployer/deploy_manager.go
@@ -14,4 +14,5 @@ type DeployManager interface {
 	TriggerLifecycleCallbacks(config builder.Config) error
 	TerminateChecking(config builder.Config) map[string]bool
 	GatherMetrics(config builder.Config) error
+	SkipDeployStep()
 }

--- a/pkg/tool/common.go
+++ b/pkg/tool/common.go
@@ -26,6 +26,16 @@ var (
 		"fatal": Logger.FatalLevel,
 		"error": Logger.ErrorLevel,
 	}
+	// STEP_CHECK_PREVIOUS = CheckPrevious
+	STEP_CHECK_PREVIOUS = int64(1)
+	// STEP_DEPLOY = Deploy
+	STEP_DEPLOY = int64(2)
+	// STEP_ADDITIONAL_WORK = FinishAdditionalWork
+	STEP_ADDITIONAL_WORK = int64(3)
+	// STEP_TRIGGER_LIFECYCLE_CALLBACK = TriggerLifecycleCallbacks
+	STEP_TRIGGER_LIFECYCLE_CALLBACK = int64(4)
+	// STEP_CLEAN_PREVIOUS_VERSION = CleanPreviousVersion
+	STEP_CLEAN_PREVIOUS_VERSION = int64(5)
 )
 
 var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")

--- a/test/test_manifest.yaml
+++ b/test/test_manifest.yaml
@@ -44,7 +44,7 @@ stacks:
   - stack: artd
     polling_interval: 20s
     account: dev
-    env: dev
+    env: dev-1
     assume_role: ""
     replacement_type: BlueGreen
     iam_instance_profile: 'app-hello-profile'
@@ -77,10 +77,11 @@ stacks:
         healthcheck_target_group: hello-artdapne2-ext
         target_groups:
           - hello-artdapne2-ext
+
   - stack: artd-spot
     polling_interval: 20s
     account: dev
-    env: dev
+    env: dev-2
     assume_role: ""
     replacement_type: BlueGreen
     iam_instance_profile: 'app-hello-profile'
@@ -133,7 +134,7 @@ stacks:
   - stack: artd-mixed
     polling_interval: 20s
     account: dev
-    env: dev
+    env: dev-3
     assume_role: ""
     replacement_type: BlueGreen
     iam_instance_profile: 'app-hello-profile'
@@ -188,7 +189,7 @@ stacks:
   - stack: artd-without-targetgroup
     polling_interval: 20s
     account: dev
-    env: dev
+    env: dev-4
     assume_role: ""
     replacement_type: BlueGreen
     iam_instance_profile: 'app-hello-profile'
@@ -223,7 +224,7 @@ stacks:
   - stack: artd-with-exact-values
     polling_interval: 20s
     account: dev
-    env: dev
+    env: dev-5
     assume_role: ""
     replacement_type: BlueGreen
     iam_instance_profile:
@@ -262,7 +263,7 @@ stacks:
   - stack: artd-with-classic-lb
     polling_interval: 20s
     account: dev
-    env: dev
+    env: dev-6
     assume_role: ""
     replacement_type: BlueGreen
     iam_instance_profile:


### PR DESCRIPTION
When deploying and deleting application, goployer used to run iteratively through whole deployers. This works well but if we support multi region and multi stack, this could be the bottle neck of malfunctioning. 

So I changed whole process to using goroutine and if a deployer fails from previous stack, then next step will be skipped. Only deployers which passed previous steps will continue to the next.