### PR TITLE
fix bug

### DIFF
--- a/pkg/aws/cloudwatch.go
+++ b/pkg/aws/cloudwatch.go
@@ -136,9 +136,9 @@ func (c CloudWatchClient) GetRequestStatistics(tgs []*string, startTime, termina
 				}
 
 				startTime = endTime.Add(1 * time.Second)
-				logger.Debugf("Start Time : %s, End Time : %s, Applied period: %d", startTime, endTime, appliedPeriod)
+				logger.Debugf("Next Start Time : %s", startTime)
 
-				if !CheckMetricTimeValidation(startTime, endTime) {
+				if !CheckMetricTimeValidation(startTime, terminatedDate) {
 					logger.Debugf("Finish gathering metrics")
 					isFinished = true
 				}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -203,6 +203,23 @@ func (b Builder) CheckValidation() error {
 		}
 	}
 
+	// duplicated value check
+	stackMap := map[string]int{}
+	for _, stack := range b.Stacks {
+		if stackMap[stack.Stack] >= 1 {
+			return fmt.Errorf("duplicated stack key between stacks : %s", stack.Stack)
+		}
+		stackMap[stack.Stack] += 1
+	}
+
+	stackMap = map[string]int{}
+	for _, stack := range b.Stacks {
+		if stackMap[stack.Env] >= 1 {
+			return fmt.Errorf("duplicated env between stacks : %s", stack.Env)
+		}
+		stackMap[stack.Env] += 1
+	}
+
 	// check validations in each stack
 	for _, stack := range b.Stacks {
 		if stack.Stack != b.Config.Stack {

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -13,12 +13,11 @@ import (
 func TestCheckValidationConfig(t *testing.T) {
 	b := Builder{
 		Config: Config{
-			Stack: "artd",
+			Stack:    "artd",
 			Manifest: "config/hello.yaml",
 			Timeout:  DEFAULT_DEPLOYMENT_TIMEOUT,
 		},
 	}
-
 
 	b.Config.Ami = "ami-test"
 	if err := b.CheckValidation(); err == nil || fmt.Sprintf("%s", err.Error()) != fmt.Sprintf("ami id cannot be used in different regions : %s", b.Config.Ami) {
@@ -107,8 +106,23 @@ func TestCheckValidationStack(t *testing.T) {
 					},
 				},
 			},
+			{
+				Stack:   "artd",
+				Account: "dev",
+				Env:     "dev",
+			},
 		},
 	}
+
+	if err := b.CheckValidation(); err == nil || err.Error() != "duplicated stack key between stacks : artd" {
+		t.Errorf("validation failed: duplicated stack key")
+	}
+	b.Stacks[1].Stack = "artd2"
+
+	if err := b.CheckValidation(); err == nil || err.Error() != "duplicated env between stacks : dev" {
+		t.Errorf("validation failed: duplicated env")
+	}
+	b.Stacks = b.Stacks[:1]
 
 	if err := b.CheckValidation(); err == nil || err.Error() != "autoscaling policy doesn't have a name" {
 		t.Errorf("validation failed: stack-autoscaling")

--- a/pkg/runner/rurnner.go
+++ b/pkg/runner/rurnner.go
@@ -485,17 +485,17 @@ func doHealthchecking(deployers []deployer.DeployManager, config builder.Config,
 			return fmt.Errorf("Timeout has been exceeded : %.0f minutes", config.Timeout.Minutes())
 		}
 
-		for _, deployer := range deployers {
-			if tool.IsStringInArray(deployer.GetStackName(), healthyStackList) {
+		for _, d := range deployers {
+			if tool.IsStringInArray(d.GetStackName(), healthyStackList) {
 				continue
 			}
 
 			count += 1
 
 			//Start healthcheck thread
-			go func() {
+			go func(deployer deployer.DeployManager) {
 				ch <- deployer.HealthChecking(config)
-			}()
+			}(d)
 		}
 
 		for count > 0 {


### PR DESCRIPTION
Fix few bugs
- `doHealthchecking` multi-thread error fix
- Currently goployer gathers only 1 day because of wrong comparison.
- If the number of current instances is larger than that in manifest, then it will follow the larger one. But when do healthchecking, this is not applied.. 


