### PR TITLE
remove env setting and fix skipping issue

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -141,10 +141,6 @@ func (b Builder) SetStacks(stacks []schemas.Stack) Builder {
 	}
 
 	for i, _ := range stacks {
-		if len(b.Config.Env) > 0 {
-			stacks[i].Env = b.Config.Env
-		}
-
 		if b.Config.PollingInterval > 0 {
 			stacks[i].PollingInterval = b.Config.PollingInterval
 		}


### PR DESCRIPTION
- If `ENV` environment variable is set, then goployer automatically accept it with --env. This changes all the env value of stacks so that error occurred. So I removed  code related to the default setting for env

- If there is no autoscaling policy or  lifecycle hook setting, it returns nil without setting the step value to true. This is considered as failure, so that the next steps are skipped.