### PR TITLE
add scheduling feature

### DIFF
--- a/codebuild-buildspec-test.yml
+++ b/codebuild-buildspec-test.yml
@@ -16,11 +16,7 @@ env:
     SLACK_TOKEN: "/CodeBuild/SLACK_TOKEN"
 
 phases:
-#  pre_build:
-#    commands:
   build:
     commands:
       - echo "Start Deployment"
-      - ./bin/goployer --manifest=configs/${SERVICE_NAME}.yaml --stack=${STACK} --region=${REGION} --ami=${BASE_AMI_ID}
-#  post_build:
-#    commands:
+      - ./bin/goployer deploy --manifest=configs/${SERVICE_NAME}.yaml --stack=${STACK} --region=${REGION} --ami=${BASE_AMI_ID} --auto-apply --slack-off=true

--- a/configs/hello.yaml
+++ b/configs/hello.yaml
@@ -41,6 +41,33 @@ tags:
   - project=test
   - repo=hello-deploy
 
+
+scheduled_actions:
+  - name: scale_in_during_weekend
+    # The recurring schedule for the action, in Unix cron syntax format. This format
+    # consists of five fields separated by white spaces: [Minute] [Hour] [Day_of_Month]
+    # [Month_of_Year] [Day_of_Week]. The value must be in quotes (for example,
+    # "30 0 1 1,6,12 *"). For more information about this format, see Crontab (http://crontab.org).
+    #
+    # When StartTime and EndTime are specified with Recurrence, they form the boundaries
+    # of when the recurring action starts and stops.
+    recurrence: "0 9 * * SAT"
+
+    # Capacity of autoscaling group
+    capacity:
+      min: 0
+      max: 0
+      desired: 0
+
+  - name: scale_out_during_weekday
+    recurrence: "0 9 * * MON"
+
+    # Capacity of autoscaling group
+    capacity:
+      min: 3
+      max: 3
+      desired: 3
+
 stacks:
   - stack: artd
 
@@ -165,6 +192,12 @@ stacks:
         # Whether or not to use detailed monitoring
         # By default, detailed monitoring is disabled
         detailed_monitoring_enabled: false
+
+        # List of scheduled actions
+        # Elements of this list should be defined in "scheduled_actions" field
+        scheduled_actions:
+          - scale_in_during_weekend
+          - scale_out_during_weekday
 
         # You can use VPC id(vpc-xxx)
         # If you specify the name of VPC, then deployer will find the VPC id with it.

--- a/examples/manifests/scheduled-actions-example.yaml
+++ b/examples/manifests/scheduled-actions-example.yaml
@@ -1,0 +1,116 @@
+---
+name: hello
+userdata:
+  type: local
+  path: scripts/userdata.sh
+
+autoscaling: &autoscaling_policy
+  - name: scale_out
+    adjustment_type: ChangeInCapacity
+    scaling_adjustment: 1
+    cooldown: 60
+  - name: scale_in
+    adjustment_type: ChangeInCapacity
+    scaling_adjustment: -1
+    cooldown: 180
+
+alarms: &autoscaling_alarms
+  - name: scale_out_on_util
+    namespace: AWS/EC2
+    metric: CPUUtilization
+    statistic: Average
+    comparison: GreaterThanOrEqualToThreshold
+    threshold: 50
+    period: 120
+    evaluation_periods: 2
+    alarm_actions:
+      - scale_out
+  - name: scale_in_on_util
+    namespace: AWS/EC2
+    metric: CPUUtilization
+    statistic: Average
+    comparison: LessThanOrEqualToThreshold
+    threshold: 30
+    period: 300
+    evaluation_periods: 3
+    alarm_actions:
+      - scale_in
+
+# Tags should be like "key=value"
+tags:
+  - project=test
+  - repo=hello-deploy
+
+
+scheduled_actions:
+  # scale in at every Saturday 09:00 AM (UTC)
+  - name: scale_in_during_weekend
+    recurrence: "0 9 * * SAT"
+    capacity:
+      min: 0
+      max: 0
+      desired: 0
+
+  # scale out at every Monday 09:00 AM (UTC)
+  - name: scale_out_during_weekday
+    recurrence: "0 9 * * MON"
+    capacity:
+      min: 3
+      max: 3
+      desired: 3
+
+stacks:
+  - stack: artd
+    polling_interval: 30s
+    account: dev
+    env: dev
+    assume_role: ""
+    replacement_type: BlueGreen
+    iam_instance_profile: 'app-hello-profile'
+    ansible_tags: all
+    ebs_optimized: true
+    instance_market_options:
+      market_type: spot
+      spot_options:
+        block_duration_minutes: 180
+        instance_interruption_behavior: terminate # terminate / stop / hibernate
+        max_price: 0.3
+        spot_instance_type: one-time # one-time or persistent
+    block_devices:
+      - device_name: /dev/xvda
+        volume_size: 10
+        volume_type: "gp2"
+      - device_name: /dev/xvdb
+        volume_type: "st1"
+        volume_size: 500
+    capacity:
+      min: 1
+      max: 2
+      desired: 1
+    autoscaling: *autoscaling_policy
+    alarms: *autoscaling_alarms
+    lifecycle_callbacks:
+      pre_terminate_past_cluster:
+        - service hello stop
+
+    regions:
+      - region: ap-northeast-2
+        instance_type: t3.medium
+        ssh_key: test-master-key
+        ami_id: ami-01288945bd24ed49a
+        use_public_subnets: true
+        scheduled_actions:
+          - scale_in_during_weekend
+          - scale_out_during_weekday
+        vpc: vpc-artd_apnortheast2
+        detailed_monitoring_enabled: false
+        security_groups:
+          - hello-artd_apnortheast2
+          - default-artd_apnortheast2
+        healthcheck_target_group: hello-artdapne2-ext
+        availability_zones:
+          - ap-northeast-2a
+          - ap-northeast-2b
+          - ap-northeast-2c
+        target_groups:
+          - hello-artdapne2-ext

--- a/hack/apitest.sh
+++ b/hack/apitest.sh
@@ -5,12 +5,15 @@ BUILD_DIR="build"
 TEST_DIR="test"
 URL="https://hello.devops-art-factory.com"
 
-stacks=("artd" "artd-spot" "artd-mixed" "artd-without-targetgroup" "artd-with-exact-values" "artd-with-classic-lb")
+stacks=("artd" "artd-spot" "artd-mixed" "artd-without-targetgroup" "artd-with-exact-values" "artd-with-classic-lb" "artd-with-scheduled-action")
 
 if [[ ! -d $BUILD_DIR ]]; then
     echo "creating new directory [ $BUILD_DIR ]"
     mkdir -p $BUILD_DIR
 fi
+
+# clean first
+make clean
 
 # process local test
 make test
@@ -23,26 +26,26 @@ if [[ $? -ne 0 ]];then
 fi
 
 # api test
-lastStack=""
-for stack in "${stacks[@]}"; do
-    echo "stack: $stack"
-    ./$BUILD_DIR/goployer deploy --auto-apply --manifest=$TEST_DIR/test_manifest.yaml --stack=$stack --slack-off=true --log-level=debug --region=ap-northeast-2 --polling-interval=20s
-    if [[ $? -eq 0 ]]; then
-        echo "$stack is deployed"
-        for ((i=1;i<=10;i++)); do
-            curl -s $URL > /dev/null
-            if [[ $? -ne 0 ]]; then
-                echo "error occurred"
-                exit 1
-            fi
-            echo "done $stack $i"
-            sleep 1
-        done
-        echo "healthcheck is done"
-    fi
-    lastStack=$stack
-    sleep 15
-done
+#lastStack=""
+#for stack in "${stacks[@]}"; do
+#    echo "stack: $stack"
+#    ./$BUILD_DIR/goployer deploy --auto-apply --manifest=$TEST_DIR/test_manifest.yaml --stack=$stack --slack-off=true --log-level=debug --region=ap-northeast-2 --polling-interval=20s
+#    if [[ $? -eq 0 ]]; then
+#        echo "$stack is deployed"
+#        for ((i=1;i<=10;i++)); do
+#            curl -s $URL > /dev/null
+#            if [[ $? -ne 0 ]]; then
+#                echo "error occurred"
+#                exit 1
+#            fi
+#            echo "done $stack $i"
+#            sleep 1
+#        done
+#        echo "healthcheck is done"
+#    fi
+#    lastStack=$stack
+#    sleep 15
+#done
 
 # Multistack
 echo "test with multistack"

--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -962,3 +962,32 @@ func (e EC2Client) UpdateAutoScalingGroup(asg string, capacity schemas.Capacity)
 
 	return nil
 }
+
+// CreateScheduledActions creates scheduled actions
+func (e EC2Client) CreateScheduledActions(asg string, actions []schemas.ScheduledAction) error {
+	input := &autoscaling.BatchPutScheduledUpdateGroupActionInput{
+		AutoScalingGroupName: aws.String(asg),
+	}
+
+	scheduledUpdateGroupActions := []*autoscaling.ScheduledUpdateGroupActionRequest{}
+	for _, a := range actions {
+		newSa := autoscaling.ScheduledUpdateGroupActionRequest{
+			ScheduledActionName: aws.String(a.Name),
+			Recurrence:          aws.String(a.Recurrence),
+			MinSize:             aws.Int64(a.Capacity.Min),
+			DesiredCapacity:     aws.Int64(a.Capacity.Desired),
+			MaxSize:             aws.Int64(a.Capacity.Max),
+		}
+
+		scheduledUpdateGroupActions = append(scheduledUpdateGroupActions, &newSa)
+	}
+
+	input.ScheduledUpdateGroupActions = scheduledUpdateGroupActions
+
+	_, err := e.AsClient.BatchPutScheduledUpdateGroupAction(input)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/deployer/bluegreen.go
+++ b/pkg/deployer/bluegreen.go
@@ -333,6 +333,22 @@ func (b BlueGreen) FinishAdditionalWork(config builder.Config) error {
 			if err := client.CloudWatchService.CreateScalingAlarms(b.AsgNames[region.Region], b.Stack.Alarms, policyArns); err != nil {
 				return err
 			}
+
+			if len(region.ScheduledActions) > 0 {
+				b.Logger.Debugf("create scheduled actions")
+				selectedActions := []schemas.ScheduledAction{}
+				for _, sa := range b.AwsConfig.ScheduledActions {
+					if tool.IsStringInArray(sa.Name, region.ScheduledActions) {
+						selectedActions = append(selectedActions, sa)
+					}
+				}
+
+				b.Logger.Debugf("selected actions [ %s ]", strings.Join(region.ScheduledActions, ","))
+				if err := client.EC2Service.CreateScheduledActions(b.AsgNames[region.Region], selectedActions); err != nil {
+					return err
+				}
+				b.Logger.Debugf("finished adding scheduled actions")
+			}
 		}
 
 	}

--- a/pkg/schemas/config.go
+++ b/pkg/schemas/config.go
@@ -13,14 +13,18 @@ type YamlConfig struct {
 	// Autoscaling tag list. This is attached to EC2 instance
 	Tags []string `yaml:"tags"`
 
+	// List of scheduled actions
+	ScheduledActions []ScheduledAction `yaml:"scheduled_actions"`
+
 	// List of stack configuration
 	Stacks []Stack `yaml:"stacks"`
 }
 
 type AWSConfig struct {
-	Name     string
-	Userdata Userdata
-	Tags     []string
+	Name             string
+	Userdata         Userdata
+	Tags             []string
+	ScheduledActions []ScheduledAction
 }
 
 // Userdata configuration
@@ -30,6 +34,18 @@ type Userdata struct {
 
 	// Path of userdata file
 	Path string `yaml:"path"`
+}
+
+// Scheduled Action configurations
+type ScheduledAction struct {
+	// Name of scheduled update action
+	Name string `yaml:"name"`
+
+	// The recurring schedule for the action, in Unix cron syntax format.
+	Recurrence string `yaml:"recurrence"`
+
+	// Capacity of autoscaling group when action is triggered
+	Capacity *Capacity `yaml:"capacity"`
 }
 
 // Stack configuration
@@ -230,6 +246,9 @@ type RegionConfig struct {
 
 	// List of security group name
 	SecurityGroups []string `yaml:"security_groups"`
+
+	// List of scheduled actions
+	ScheduledActions []string `yaml:"scheduled_actions"`
 
 	// Class load balancer name for healthcheck
 	HealthcheckLB string `yaml:"healthcheck_load_balancer"`

--- a/pkg/tool/common.go
+++ b/pkg/tool/common.go
@@ -18,6 +18,7 @@ var (
 	HOURTOSEC               = int64(3600)
 	allowedAnswerYes        = []string{"y", "yes"}
 	allowedAnswerNo         = []string{"n", "no"}
+	DaysOfWeek              = []string{"MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN", "0", "1", "2", "3", "4", "5", "6", "7"}
 	LogLevelMapper          = map[string]Logger.Level{
 		"info":  Logger.InfoLevel,
 		"debug": Logger.DebugLevel,

--- a/test/test_manifest.yaml
+++ b/test/test_manifest.yaml
@@ -40,6 +40,24 @@ tags:
   - project=test
   - repo=hello-deploy
 
+
+scheduled_actions:
+  # scale in at every Saturday 09:00 AM (UTC)
+  - name: scale_in_during_weekend
+    recurrence: "0 9 * * SAT"
+    capacity:
+      min: 0
+      max: 0
+      desired: 0
+
+  # scale out at every Monday 09:00 AM (UTC)
+  - name: scale_out_during_weekday
+    recurrence: "0 9 * * MON"
+    capacity:
+      min: 1
+      max: 1
+      desired: 1
+
 stacks:
   - stack: artd
     polling_interval: 20s
@@ -301,8 +319,46 @@ stacks:
         security_groups:
           - hello-artd_apnortheast2
           - default-artd_apnortheast2
+
+  - stack: artd-with-scheduled-action
+    polling_interval: 20s
+    account: dev
+    env: dev-7
+    assume_role: ""
+    replacement_type: BlueGreen
+    iam_instance_profile:
+    tags:
+      - test-stack=artd-with-exact-values
+    ebs_optimized: true
+
+    # capacity
+    capacity:
+      min: 1
+      max: 2
+      desired: 1
+
+    autoscaling: *autoscaling_policy
+    alarms: *autoscaling_alarms
+
+    lifecycle_callbacks:
+      pre_terminate_past_cluster:
+        - service hello stop
+
+    regions:
+      - region: ap-northeast-2
+        instance_type: t3.medium
+        ssh_key: test-master-key
+        ami_id: ami-01288945bd24ed49a
+        scheduled_actions:
+          - scale_in_during_weekend
+          - scale_out_during_weekday
+        use_public_subnets: true
+        vpc: vpc-05be14885b028018d
+        detailed_monitoring_enabled: false
+        security_groups:
+          - hello-artd_apnortheast2
+          - default-artd_apnortheast2
         availability_zones:
           - ap-northeast-2a
           - ap-northeast-2b
           - ap-northeast-2c
-


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #84  <!-- tracking issues that this PR will close -->

**Description**
scheduling action is used when users want to control capacity based on schedules. Schedules are added based on cron expression.

**User facing changes (remove if N/A)**
You can specify scheduled_actions like below and specify the names of actions in the region configurations.
```
scheduled_actions:
  # scale in at every Saturday 09:00 AM (UTC)
  - name: scale_in_during_weekend
    recurrence: "0 9 * * SAT"
    capacity:
      min: 0
      max: 0
      desired: 0

  # scale out at every Monday 09:00 AM (UTC)
  - name: scale_out_during_weekday
    recurrence: "0 9 * * MON"
    capacity:
      min: 1
      max: 1
      desired: 1

stacks:
  - stack: artd
     ... 
    regions:
      - region: ap-northeast-2
        instance_type: t3.medium
        .... 
        scheduled_actions:
          - scale_in_during_weekend
          - scale_out_during_weekday
```

**Follow-up Work (remove if N/A)**
Documentation because releasing


**Release notes**
```
Scheduled actions feature is supported.
```
