### PR TITLE
fix cloudwatch metrics

### DIFF
--- a/cmd/goployer/cmd/flag.go
+++ b/cmd/goployer/cmd/flag.go
@@ -64,7 +64,7 @@ var CommonFlagRegistry = []Flag{
 		Shorthand:     "p",
 		Usage:         "Profile configuration of AWS",
 		Value:         aws.String(constants.EmptyString),
-		DefValue:      constants.DefaultProfile,
+		DefValue:      constants.EmptyString,
 		FlagAddMethod: "StringVar",
 	},
 }

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -49,6 +49,10 @@ type ManifestClient struct {
 func GetAwsSession() *session.Session {
 	profile := viper.GetString("profile")
 
+	if len(profile) == 0 {
+		return session.Must(session.NewSession())
+	}
+
 	mySession := session.Must(
 		session.NewSession(&aws.Config{
 			Credentials: credentials.NewCredentials(&credentials.SharedCredentialsProvider{
@@ -57,6 +61,7 @@ func GetAwsSession() *session.Session {
 			}),
 		}),
 	)
+
 	return mySession
 }
 

--- a/pkg/aws/cloudwatch.go
+++ b/pkg/aws/cloudwatch.go
@@ -37,20 +37,22 @@ type CloudWatchClient struct {
 	Client *cloudwatch.CloudWatch
 }
 
+// NewCloudWatchClient creates Cloudwatch client
 func NewCloudWatchClient(session client.ConfigProvider, region string, creds *credentials.Credentials) CloudWatchClient {
 	return CloudWatchClient{
-		Client: getCloudwatchClientFn(session, region, creds),
+		Client: getCloudWatchClientFn(session, region, creds),
 	}
 }
 
-func getCloudwatchClientFn(session client.ConfigProvider, region string, creds *credentials.Credentials) *cloudwatch.CloudWatch {
+// getCloudWatchClientFn creates new cloudwatch client
+func getCloudWatchClientFn(session client.ConfigProvider, region string, creds *credentials.Credentials) *cloudwatch.CloudWatch {
 	if creds == nil {
 		return cloudwatch.New(session, &aws.Config{Region: aws.String(region)})
 	}
 	return cloudwatch.New(session, &aws.Config{Region: aws.String(region), Credentials: creds})
 }
 
-//CreateScalingAlarms creates scaling alarms
+// CreateScalingAlarms creates scaling alarms
 func (c CloudWatchClient) CreateScalingAlarms(asgName string, alarms []schemas.AlarmConfigs, policyArns map[string]string) error {
 	if len(alarms) == 0 {
 		return nil
@@ -71,7 +73,7 @@ func (c CloudWatchClient) CreateScalingAlarms(asgName string, alarms []schemas.A
 	return nil
 }
 
-// Create cloudwatch alarms for autoscaling group
+// CreateCloudWatchAlarm creates cloudwatch alarms for autoscaling group
 func (c CloudWatchClient) CreateCloudWatchAlarm(asgName string, alarm schemas.AlarmConfigs) error {
 	input := &cloudwatch.PutMetricAlarmInput{
 		AlarmName:          aws.String(alarm.Name),
@@ -113,15 +115,15 @@ func (c CloudWatchClient) CreateCloudWatchAlarm(asgName string, alarm schemas.Al
 	return nil
 }
 
-// GetRequestStatics returns statistics for terminating autoscaling group
-func (c CloudWatchClient) GetRequestStatistics(tgs []*string, startTime, terminatedDate time.Time, logger *Logger.Logger) (map[string]map[string]float64, error) {
+// GetTargetGroupRequestStatistics returns statistics for terminating autoscaling group
+func (c CloudWatchClient) GetTargetGroupRequestStatistics(tgs []*string, startTime, terminatedDate time.Time, logger *Logger.Logger) (map[string]map[string]float64, error) {
 	ret := map[string]map[string]float64{}
 
 	resetStartTime := startTime
 	if len(tgs) > 0 {
 		for _, tg := range tgs {
 			tgName := (*tg)[strings.LastIndex(*tg, ":")+1:]
-			logger.Debugf("GetRequestStatistics: %s", tgName)
+			logger.Debugf("GetTargetGroupRequestStatistics: %s", tgName)
 
 			appliedPeriod := constants.HourToSec
 			vSum := float64(0)
@@ -144,7 +146,7 @@ func (c CloudWatchClient) GetRequestStatistics(tgs []*string, startTime, termina
 					break
 				}
 
-				v, s, err := c.GetOneDayStatistics(tgName, startTime, endTime, appliedPeriod, id)
+				v, s, err := c.GetOneDayStatisticsOfTargetGroup(tgName, startTime, endTime, appliedPeriod, id)
 				if err != nil {
 					return nil, err
 				}
@@ -173,8 +175,68 @@ func (c CloudWatchClient) GetRequestStatistics(tgs []*string, startTime, termina
 	return ret, nil
 }
 
-// GetOneDayStatistics returns all stats of one day
-func (c CloudWatchClient) GetOneDayStatistics(tg string, startTime, endTime time.Time, period int64, id string) (map[string]float64, float64, error) {
+// GetLoadBalancerRequestStatistics returns statistics for terminating autoscaling group
+func (c CloudWatchClient) GetLoadBalancerRequestStatistics(loadbalancers []*string, startTime, terminatedDate time.Time, logger *Logger.Logger) (map[string]map[string]float64, error) {
+	ret := map[string]map[string]float64{}
+
+	resetStartTime := startTime
+	if len(loadbalancers) > 0 {
+		for _, lb := range loadbalancers {
+			lbName := (*lb)[strings.Index(*lb, "/")+1:]
+			logger.Debugf("GetLoadBalancerRequestStatistics: %s", lbName)
+
+			appliedPeriod := constants.HourToSec
+			vSum := constants.ZeroFloat64
+
+			startTime = resetStartTime
+			isFinished := false
+			for !isFinished {
+				id := fmt.Sprintf("m%s", tool.GetTimePrefix(startTime))
+				logger.Debugf("Metric id : %s", id)
+
+				endTime := tool.GetBaseTime(startTime.Add(time.Duration(constants.DayToSec) * time.Second)).Add(-1 * time.Second)
+				if CheckMetricTimeValidation(terminatedDate, endTime) {
+					logger.Debugf("Terminated Date is earlier than End Date: %s/%s", terminatedDate, endTime)
+					endTime = terminatedDate
+				}
+				logger.Debugf("Start Time : %s, End Time : %s, Applied period: %d", startTime, endTime, appliedPeriod)
+
+				if !CheckMetricTimeValidation(startTime, endTime) {
+					logger.Debugf("Finish gathering metrics")
+					break
+				}
+
+				v, s, err := c.GetOneDayStatisticsOfLoadBalancer(lbName, startTime, endTime, appliedPeriod, id)
+				if err != nil {
+					return nil, err
+				}
+
+				if v != nil {
+					ret[lbName] = v
+					vSum += s
+				}
+
+				startTime = endTime.Add(1 * time.Second)
+				logger.Debugf("Next Start Time : %s", startTime)
+
+				if !CheckMetricTimeValidation(startTime, terminatedDate) {
+					logger.Debugf("Finish gathering metrics")
+					isFinished = true
+				}
+			}
+
+			if ret[lbName] == nil {
+				ret[lbName] = map[string]float64{}
+			}
+			ret[lbName]["total"] = vSum
+		}
+	}
+
+	return ret, nil
+}
+
+// GetOneDayStatisticsOfTargetGroup returns all stats of one day
+func (c CloudWatchClient) GetOneDayStatisticsOfTargetGroup(tg string, startTime, endTime time.Time, period int64, id string) (map[string]float64, float64, error) {
 	input := &cloudwatch.GetMetricDataInput{
 		StartTime: aws.Time(startTime),
 		EndTime:   aws.Time(endTime),
@@ -231,6 +293,63 @@ func (c CloudWatchClient) GetOneDayStatistics(tg string, startTime, endTime time
 	return ret, sum, nil
 }
 
+// GetOneDayStatisticsOfLoadBalancer returns all stats of one day
+func (c CloudWatchClient) GetOneDayStatisticsOfLoadBalancer(lb string, startTime, endTime time.Time, period int64, id string) (map[string]float64, float64, error) {
+	input := &cloudwatch.GetMetricDataInput{
+		StartTime: aws.Time(startTime),
+		EndTime:   aws.Time(endTime),
+	}
+
+	var mdq []*cloudwatch.MetricDataQuery
+	mdq = append(mdq, &cloudwatch.MetricDataQuery{
+		Id:         aws.String(id),
+		ReturnData: aws.Bool(false),
+		MetricStat: &cloudwatch.MetricStat{
+			Metric: &cloudwatch.Metric{
+				Dimensions: []*cloudwatch.Dimension{
+					{
+						Name:  aws.String("LoadBalancer"),
+						Value: aws.String(lb),
+					},
+				},
+				MetricName: aws.String("RequestCount"),
+				Namespace:  aws.String("AWS/ApplicationELB"),
+			},
+			Period: aws.Int64(period),
+			Stat:   aws.String("Sum"),
+		},
+	})
+
+	mdq = append(mdq, &cloudwatch.MetricDataQuery{
+		Expression: aws.String(id),
+		Id:         aws.String(fmt.Sprintf("%s%s", "t", id)),
+		Label:      aws.String("RequestSum"),
+	})
+
+	input.MetricDataQueries = mdq
+
+	result, err := c.Client.GetMetricData(input)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// If no result exists, then set it to zero
+	if len(result.MetricDataResults) == 0 {
+		return nil, 0, nil
+	}
+
+	ret := map[string]float64{}
+	sum := float64(0)
+	for i, t := range result.MetricDataResults[0].Timestamps {
+		val := *result.MetricDataResults[0].Values[i]
+		ret[t.Format(time.RFC3339)] = val
+		sum += val
+	}
+
+	return ret, sum, nil
+}
+
+// CheckMetricTimeValidation validates metric time
 func CheckMetricTimeValidation(startTime time.Time, endTime time.Time) bool {
 	return endTime.Sub(startTime) > 0
 }

--- a/pkg/aws/dynamodb.go
+++ b/pkg/aws/dynamodb.go
@@ -265,6 +265,7 @@ func (d DynamoDBClient) UpdateRecord(updateKey, asg string, tableName string, st
 	return nil
 }
 
+// GetSingleItem retrieves single item for single autoscaling group
 func (d DynamoDBClient) GetSingleItem(asg, tableName string) (map[string]*dynamodb.AttributeValue, error) {
 	input := &dynamodb.GetItemInput{
 		Key: map[string]*dynamodb.AttributeValue{
@@ -311,7 +312,7 @@ func (d DynamoDBClient) UpdateStatistics(asg string, tableName, timezone string,
 			ex = fmt.Sprintf("%s, #%s = :%s", ex, k, k)
 			input.UpdateExpression = aws.String(ex)
 			input.ExpressionAttributeNames[fmt.Sprintf("#%s", k)] = aws.String(k)
-			if k != "stat" {
+			if !tool.IsStringInArray(k, []string{"tg_request_count", "lb_request_count"}) {
 				input.ExpressionAttributeValues[fmt.Sprintf(":%s", k)] = &dynamodb.AttributeValue{
 					S: aws.String(v.(string)),
 				}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -24,6 +24,9 @@ import (
 )
 
 const (
+	// Current Base Year
+	YearNow = 2020
+
 	// DefaultLogLevel is the default global verbosity
 	DefaultLogLevel = logrus.WarnLevel
 
@@ -32,6 +35,9 @@ const (
 
 	// EmptyString is the empty string
 	EmptyString = ""
+
+	// ZeroFloat64 means 0 in float64 format
+	ZeroFloat64 = float64(0)
 
 	// DefaultProfile is the default aws profile
 	DefaultProfile = "default"
@@ -90,6 +96,9 @@ const (
 	// InitialStatus is the initial status of instances in classic LB
 	InitialStatus = "Not Found"
 
+	// MonthToSec changes a month to seconds
+	MonthToSec = float64(2592000)
+
 	// DayToSec changes a day to seconds
 	DayToSec = int64(86400)
 
@@ -110,6 +119,9 @@ const (
 
 	// StepCleanPreviousVersion = CleanPreviousVersion
 	StepCleanPreviousVersion = int64(5)
+
+	// DefaultEnableStats is whether or not to enable gathering stats
+	DefaultEnableStats = true
 )
 
 var (
@@ -149,6 +161,9 @@ var (
 
 	// DaysOfWeek is a list of possible string value for cron expression
 	DaysOfWeek = []string{"MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN", "0", "1", "2", "3", "4", "5", "6", "7"}
+
+	// MinTimestamp means minimum timestamp YEAR/01/01 00:00:00 UTC
+	MinTimestamp = time.Date(YearNow, time.January, 1, 0, 0, 0, 0, time.UTC)
 )
 
 // Get Home Directory

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -249,8 +249,13 @@ func (d Deployer) GatherMetrics(client aws.Client, asg string) error {
 		return nil
 	}
 
+	lbs, err := client.ELBV2Service.GetLoadBalancerFromTG(targetGroups)
+	if err != nil {
+		return err
+	}
+
 	d.Logger.Debugf("start retrieving additional metrics")
-	metricData, err := d.Collector.GetAdditionalMetric(asg, targetGroups, d.Logger)
+	metricData, err := d.Collector.GetAdditionalMetric(asg, targetGroups, lbs, d.Logger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently, goployer collects RequestCountPerTarget which means the number of API calls in the instance among target group in average.

We need a total number of API calls in the load balancer in order to check all API calls.