### PR TITLE
add io2 and modify documentation

### DIFF
--- a/cmd/goployer/cmd/cmd.go
+++ b/cmd/goployer/cmd/cmd.go
@@ -36,7 +36,7 @@ var (
 )
 
 // NewRootCommand creates new root command
-func NewRootCommand(_, stderr io.Writer) *cobra.Command {
+func NewRootCommand(out, stderr io.Writer) *cobra.Command {
 	cobra.OnInitialize(initConfig)
 	rootCmd := &cobra.Command{
 		Use:   "goployer",
@@ -47,6 +47,8 @@ You can find more information in https://goployer.dev`,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			cmd.Root().SetOutput(out)
+
 			// Setup logs
 			if err := setUpLogs(stderr, v); err != nil {
 				return err
@@ -71,7 +73,7 @@ You can find more information in https://goployer.dev`,
 	rootCmd.AddCommand(NewAddCommand())
 	rootCmd.AddCommand(NewUpdateCommand())
 
-	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", constants.DefaultLogLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
+	rootCmd.PersistentFlags().StringVarP(&v, "log-level", "v", constants.DefaultLogLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
 
 	return rootCmd
 }

--- a/cmd/goployer/cmd/flag.go
+++ b/cmd/goployer/cmd/flag.go
@@ -138,8 +138,9 @@ var FlagRegistry = map[string][]Flag{
 		{
 			Name:          "log-level",
 			Usage:         "Level of logging",
+			Shorthand:     "v",
 			Value:         aws.String(constants.EmptyString),
-			DefValue:      "info",
+			DefValue:      "warning",
 			FlagAddMethod: "StringVar",
 		},
 		{
@@ -210,8 +211,9 @@ var FlagRegistry = map[string][]Flag{
 		{
 			Name:          "log-level",
 			Usage:         "Level of logging",
+			Shorthand:     "v",
 			Value:         aws.String(constants.EmptyString),
-			DefValue:      "info",
+			DefValue:      "warning",
 			FlagAddMethod: "StringVar",
 		},
 	},
@@ -219,8 +221,9 @@ var FlagRegistry = map[string][]Flag{
 		{
 			Name:          "log-level",
 			Usage:         "Level of logging",
+			Shorthand:     "v",
 			Value:         aws.String(constants.EmptyString),
-			DefValue:      "info",
+			DefValue:      "warning",
 			FlagAddMethod: "StringVar",
 		},
 	},

--- a/configs/hello.yaml
+++ b/configs/hello.yaml
@@ -144,8 +144,9 @@ stacks:
     # If you do not set volume_type, it would be gp2.
     block_devices:
       - device_name: /dev/xvda
-        volume_size: 100
-        volume_type: "gp2"
+        volume_size: 8
+        volume_type: "io2"
+        iops: 200
       - device_name: /dev/xvdb
         volume_type: "st1"
         volume_size: 500

--- a/docs/content/en/docs/References/commandline/_index.md
+++ b/docs/content/en/docs/References/commandline/_index.md
@@ -14,6 +14,7 @@ Initiate project:
 
 Retrieve and Modify deployment:
 * [goployer status](#goployer-status) -  Retrieve information of the specific deployment
+* [goployer update](#goployer-update) -  Update configuration of deployment without re-deployment
 
 <br>
 
@@ -23,7 +24,8 @@ Total Deployment Process:
 
 ## goployer init
 - setup goployer project
-```
+
+```bash
 Examples:
   # Minimum argument
   goployer init
@@ -31,11 +33,15 @@ Examples:
   # See log
   goployer init --log-level=debug
 
-Options:
-      --log-level string                Level of logging
+Flags:
+  -h, --help             help for init
+  -p, --profile string   Profile configuration of AWS
+
+Global Flags:
+  -v, --log-level string   Log level (debug, info, warn, error, fatal, panic) (default "warning")
 ```
 
-- All project files will be created in current directory.
+- All project files will be created in the current directory.
   - manifests
   - scripts
   - metric.yaml
@@ -43,7 +49,8 @@ Options:
 
 ## goployer add
 - add new goployer manifest file 
-```
+
+```bash
 Examples:
   # Minimum argument
   goployer add 
@@ -51,29 +58,104 @@ Examples:
   # You can specify application name from command
   goployer add hello
 
-Options:
-      --log-level string                Level of logging
+Flags:
+  -h, --help             help for add
+  -p, --profile string   Profile configuration of AWS
+
+Global Flags:
+  -v, --log-level string   Log level (debug, info, warn, error, fatal, panic) (default "warning")
 ```
 <br>
 
 
 ## goployer status
 -  Retrieve information of the specific deployment
-```
+
+```bash
 Examples:
   # Minimum argument
+  goployer status hello 
+
+  # With region
   goployer status hello --region=ap-northeast-2
 
-Options:
-      --region string                  Region of autoscaling group
+Usage:
+  goployer status [flags]
+
+Flags:
+  -h, --help             help for status
+  -p, --profile string   Profile configuration of AWS
+      --region string    Region of autoscaling group
+
+Global Flags:
+  -v, --log-level string   Log level (debug, info, warn, error, fatal, panic) (default "warning")
+```
+
+```bash
+$ goployer status hello
+? Choose autoscaling group: hello-dev_apnortheast2-v003
+Name:           hello-dev_apnortheast2-v003
+Created Time:   2020-09-16 10:29:21.169 +0000 UTC
+
+📦 Capacity
+MINIMUM    DESIRED    MAXIMUM
+1          1          2
+
+🖥 Instance Statistics
+ ∙ t3.medium: 1
+
+⚓ Tags
+ ∙ Name=hello-dev_apnortheast2-v003
+ ∙ ansible-tags=all
+ ∙ app=hello
+ ∙ project=test
+ ∙ repo=hello-deploy
+ ∙ stack=_apnortheast2
+ ∙ stack-name=artd
+ ∙ test=test
 ```
 <br>
+
+## goployer update
+-  Update configuration of deployment without re-deployment
+  - Capacity modification: change value of min/desired/max
+
+```bash
+Examples:
+  # Minimum argument
+  # at least one of `--min, --max, --desired` is needed
+  goployer update hello --desired=1 --min=0 --max=1
+
+  # Auto apply without confirmation
+  goployer update hello --desired=1 --auto-apply
+
+  # Update with other options
+  goployer update hello --desired=1 --region=ap-northeast-2 --auto-apply --polling-interval=20s
+
+Usage:
+  goployer update name-prefix [flags] 
+
+Flags:
+      --auto-apply                  Apply command without confirmation from local terminal
+      --desired int                 Desired instance capacity you want to update with (default -1)
+  -h, --help                        help for update
+      --max int                     Maximum instance capacity you want to update with (default -1)
+      --min int                     Minimum instance capacity you want to update with (default -1)
+      --polling-interval duration   Time to interval for polling health check (default 60s) (default 1m0s)
+  -p, --profile string              Profile configuration of AWS
+      --region string               Region of autoscaling group
+      --timeout duration            Time to wait for deploy to finish before timing out (default 60m) (default 1h0m0s)
+
+Global Flags:
+  -v, --log-level string   Log level (debug, info, warn, error, fatal, panic) (default "warning")
+```
+<br>
+
 
 ## goployer deploy
 - Deploy a new application
 
-```
-
+```bash
 Examples:
   # Minimum argument
   goployer deploy --manifest=configs/hello.yaml --stack=artd --region=ap-northeast-2
@@ -87,26 +169,30 @@ Examples:
   # Control polling interval for healthcheck
   goployer deploy --manifest=configs/hello.yaml --stack=artd --region=ap-northeast-2 --polling-interval=30s
 
-Options:
-  -m, --manifest string                 The manifest configuration file to use. (required)
-      --stack string                    stack that should be deployed.(required)
-      --manifest-s3-region string       Region of bucket containing the manifest configuration file to use. (required if –manifest starts with s3://)
+Flags:
       --ami string                      Amazon AMI to use.
       --ansible-extra-vars string       Extra variables for ansible
       --assume-role string              The Role ARN to assume into.
+      --auto-apply                      Apply command without confirmation from local terminal
       --disable-metrics                 Disable gathering metrics.
       --env string                      The environment that is being deployed into.
       --extra-tags string               Extra tags to add to autoscaling group tags
       --force-manifest-capacity         Force-apply the capacity of instances in the manifest file
-      --log-level string                Level of logging
+  -h, --help                            help for deploy
+  -m, --manifest string                 The manifest configuration file to use. (required)
+      --manifest-s3-region string       Region of bucket containing the manifest configuration file to use. (required if –manifest starts with s3://)
       --override-instance-type string   Instance Type to override
       --polling-interval duration       Time to interval for polling health check (default 60s) (default 1m0s)
+  -p, --profile string                  Profile configuration of AWS
       --region string                   The region to deploy into, if undefined, then the deployment will run against all regions for the given environment.
       --release-notes string            Release note for the current deployment
       --release-notes-base64 string     Base64 encoded string of release note for the current deployment
       --slack-off                       Turn off slack alarm
+      --stack string                    stack that should be deployed.(required)
       --timeout duration                Time to wait for deploy to finish before timing out (default 60m) (default 1h0m0s)
-      --auto-apply                      Apply command without confirmation from local terminal
+
+Global Flags:
+  -v, --log-level string   Log level (debug, info, warn, error, fatal, panic) (default "warning")
 ```
 <br>
 
@@ -115,8 +201,8 @@ Options:
 
 ## goployer delete
 - Delete previous applications
-```
 
+```bash
 Examples:
   # Minimum argument
   goployer delete --manifest=configs/hello.yaml --stack=artd --region=ap-northeast-2
@@ -127,18 +213,30 @@ Examples:
   # Control polling interval for healthcheck
   goployer delete --manifest=configs/hello.yaml --stack=artd --region=ap-northeast-2 --polling-interval=30s
 
-Options:
-  -m, --manifest string                 The manifest configuration file to use. (required)
-      --stack string                    stack that should be deployed.(required)
-      --manifest-s3-region string       Region of bucket containing the manifest configuration file to use. (required if –manifest starts with s3://)
-      --region string                   The region to deploy into, if undefined, then the deployment will run against all regions for the given environment.
+Flags:
+      --ami string                      Amazon AMI to use.
+      --ansible-extra-vars string       Extra variables for ansible
       --assume-role string              The Role ARN to assume into.
+      --auto-apply                      Apply command without confirmation from local terminal
       --disable-metrics                 Disable gathering metrics.
       --env string                      The environment that is being deployed into.
-      --log-level string                Level of logging
+      --extra-tags string               Extra tags to add to autoscaling group tags
+      --force-manifest-capacity         Force-apply the capacity of instances in the manifest file
+  -h, --help                            help for delete
+  -m, --manifest string                 The manifest configuration file to use. (required)
+      --manifest-s3-region string       Region of bucket containing the manifest configuration file to use. (required if –manifest starts with s3://)
+      --override-instance-type string   Instance Type to override
       --polling-interval duration       Time to interval for polling health check (default 60s) (default 1m0s)
+  -p, --profile string                  Profile configuration of AWS
+      --region string                   The region to deploy into, if undefined, then the deployment will run against all regions for the given environment.
+      --release-notes string            Release note for the current deployment
+      --release-notes-base64 string     Base64 encoded string of release note for the current deployment
+      --slack-off                       Turn off slack alarm
+      --stack string                    stack that should be deployed.(required)
       --timeout duration                Time to wait for deploy to finish before timing out (default 60m) (default 1h0m0s)
-      --auto-apply                      Apply command without confirmation from local terminal
+
+Global Flags:
+  -v, --log-level string   Log level (debug, info, warn, error, fatal, panic) (default "warning")
 ```
 <br>
 

--- a/docs/content/en/schemas/metric.json
+++ b/docs/content/en/schemas/metric.json
@@ -11,7 +11,8 @@
         "region": {
           "type": "string",
           "description": "Base region for gathering metrics",
-          "x-intellij-html-description": "Base region for gathering metrics"
+          "x-intellij-html-description": "Base region for gathering metrics",
+          "default": "\"\""
         },
         "storage": {
           "$ref": "#/definitions/Storage",
@@ -27,17 +28,23 @@
       "description": "Metric Builder Configurations",
       "x-intellij-html-description": "Metric Builder Configurations"
     },
+    "Metrics": {
+      "description": "Configurations of metrics",
+      "x-intellij-html-description": "Configurations of metrics"
+    },
     "Storage": {
       "properties": {
         "name": {
           "type": "string",
           "description": "Storage Name",
-          "x-intellij-html-description": "Storage Name"
+          "x-intellij-html-description": "Storage Name",
+          "default": "\"\""
         },
         "type": {
           "type": "string",
           "description": "Storage Type - dynamodb",
-          "x-intellij-html-description": "Storage Type - dynamodb"
+          "x-intellij-html-description": "Storage Type - dynamodb",
+          "default": "\"\""
         }
       },
       "additionalProperties": false,

--- a/docs/content/en/schemas/schema.json
+++ b/docs/content/en/schemas/schema.json
@@ -10,7 +10,8 @@
       "properties": {
         "alarm_actions": {
           "items": {
-            "type": "string"
+            "type": "string",
+            "default": "\"\""
           },
           "type": "array",
           "description": "List of actions when alarm is triggered Element of this list should be defined with scaling_policy",
@@ -20,7 +21,8 @@
         "evaluation_periods": {
           "type": "integer",
           "description": "The number of periods for evaluation",
-          "x-intellij-html-description": "The number of periods for evaluation"
+          "x-intellij-html-description": "The number of periods for evaluation",
+          "default": "0"
         }
       },
       "additionalProperties": false,
@@ -36,24 +38,34 @@
         "device_name": {
           "type": "string",
           "description": "Name of block device",
-          "x-intellij-html-description": "Name of block device"
+          "x-intellij-html-description": "Name of block device",
+          "default": "\"\""
+        },
+        "iops": {
+          "type": "integer",
+          "description": "IOPS for io1, io2 volume",
+          "x-intellij-html-description": "IOPS for io1, io2 volume",
+          "default": "0"
         },
         "volume_size": {
           "type": "integer",
           "description": "Size of volume",
-          "x-intellij-html-description": "Size of volume"
+          "x-intellij-html-description": "Size of volume",
+          "default": "0"
         },
         "volume_type": {
           "type": "string",
-          "description": "Type of volume (gp2, io1, st1, sc1)",
-          "x-intellij-html-description": "Type of volume (gp2, io1, st1, sc1)"
+          "description": "Type of volume (gp2, io1, io2, st1, sc1)",
+          "x-intellij-html-description": "Type of volume (gp2, io1, io2, st1, sc1)",
+          "default": "\"\""
         }
       },
       "additionalProperties": false,
       "preferredOrder": [
         "device_name",
         "volume_size",
-        "volume_type"
+        "volume_type",
+        "iops"
       ],
       "description": "EBS Block device configuration",
       "x-intellij-html-description": "EBS Block device configuration"
@@ -63,17 +75,20 @@
         "desired": {
           "type": "integer",
           "description": "number of instances",
-          "x-intellij-html-description": "number of instances"
+          "x-intellij-html-description": "number of instances",
+          "default": "0"
         },
         "max": {
           "type": "integer",
           "description": "Maximum number of instances",
-          "x-intellij-html-description": "Maximum number of instances"
+          "x-intellij-html-description": "Maximum number of instances",
+          "default": "0"
         },
         "min": {
           "type": "integer",
           "description": "Minimum number of instances",
-          "x-intellij-html-description": "Minimum number of instances"
+          "x-intellij-html-description": "Minimum number of instances",
+          "default": "0"
         }
       },
       "additionalProperties": false,
@@ -90,7 +105,8 @@
         "market_type": {
           "type": "string",
           "description": "Type of market for EC2 instance",
-          "x-intellij-html-description": "Type of market for EC2 instance"
+          "x-intellij-html-description": "Type of market for EC2 instance",
+          "default": "\"\""
         },
         "spot_options": {
           "$ref": "#/definitions/SpotOptions",
@@ -110,7 +126,8 @@
       "properties": {
         "pre_terminate_past_cluster": {
           "items": {
-            "type": "string"
+            "type": "string",
+            "default": "\"\""
           },
           "type": "array",
           "description": "List of command before terminating previous autoscaling group",
@@ -130,32 +147,38 @@
         "default_result": {
           "type": "string",
           "description": "Default result of lifecycle hook",
-          "x-intellij-html-description": "Default result of lifecycle hook"
+          "x-intellij-html-description": "Default result of lifecycle hook",
+          "default": "\"\""
         },
         "heartbeat_timeout": {
           "type": "integer",
           "description": "Heartbeat timeout of lifecycle hook",
-          "x-intellij-html-description": "Heartbeat timeout of lifecycle hook"
+          "x-intellij-html-description": "Heartbeat timeout of lifecycle hook",
+          "default": "0"
         },
         "lifecycle_hook_name": {
           "type": "string",
           "description": "Name of lifecycle hook",
-          "x-intellij-html-description": "Name of lifecycle hook"
+          "x-intellij-html-description": "Name of lifecycle hook",
+          "default": "\"\""
         },
         "notification_metadata": {
           "type": "string",
           "description": "Notification Metadata of lifecycle hook",
-          "x-intellij-html-description": "Notification Metadata of lifecycle hook"
+          "x-intellij-html-description": "Notification Metadata of lifecycle hook",
+          "default": "\"\""
         },
         "notification_target_arn": {
           "type": "string",
           "description": "Notification Target ARN like AWS Simple Notification Service",
-          "x-intellij-html-description": "Notification Target ARN like AWS Simple Notification Service"
+          "x-intellij-html-description": "Notification Target ARN like AWS Simple Notification Service",
+          "default": "\"\""
         },
         "role_arn": {
           "type": "string",
           "description": "IAM Role ARN for notification",
-          "x-intellij-html-description": "IAM Role ARN for notification"
+          "x-intellij-html-description": "IAM Role ARN for notification",
+          "default": "\"\""
         }
       },
       "additionalProperties": false,
@@ -208,11 +231,13 @@
         "on_demand_percentage": {
           "type": "integer",
           "description": "Percentage of On Demand instance",
-          "x-intellij-html-description": "Percentage of On Demand instance"
+          "x-intellij-html-description": "Percentage of On Demand instance",
+          "default": "0"
         },
         "override_instance_types": {
           "items": {
-            "type": "string"
+            "type": "string",
+            "default": "\"\""
           },
           "type": "array",
           "description": "List of EC2 instance types for spot instance",
@@ -222,17 +247,20 @@
         "spot_allocation_strategy": {
           "type": "string",
           "description": "Allocation strategy for spot instances",
-          "x-intellij-html-description": "Allocation strategy for spot instances"
+          "x-intellij-html-description": "Allocation strategy for spot instances",
+          "default": "\"\""
         },
         "spot_instance_pools": {
           "type": "integer",
           "description": "The number of pools of instance type for spot instances",
-          "x-intellij-html-description": "The number of pools of instance type for spot instances"
+          "x-intellij-html-description": "The number of pools of instance type for spot instances",
+          "default": "0"
         },
         "spot_max_price": {
           "type": "string",
           "description": "Maximum spot price",
-          "x-intellij-html-description": "Maximum spot price"
+          "x-intellij-html-description": "Maximum spot price",
+          "default": "\"\""
         }
       },
       "additionalProperties": false,
@@ -252,11 +280,13 @@
         "ami_id": {
           "type": "string",
           "description": "Amazon AMI ID",
-          "x-intellij-html-description": "Amazon AMI ID"
+          "x-intellij-html-description": "Amazon AMI ID",
+          "default": "\"\""
         },
         "availability_zones": {
           "items": {
-            "type": "string"
+            "type": "string",
+            "default": "\"\""
           },
           "type": "array",
           "description": "Availability zones for autoscaling group",
@@ -272,21 +302,25 @@
         "healthcheck_load_balancer": {
           "type": "string",
           "description": "Class load balancer name for healthcheck",
-          "x-intellij-html-description": "Class load balancer name for healthcheck"
+          "x-intellij-html-description": "Class load balancer name for healthcheck",
+          "default": "\"\""
         },
         "healthcheck_target_group": {
           "type": "string",
           "description": "Target group name for healthcheck",
-          "x-intellij-html-description": "Target group name for healthcheck"
+          "x-intellij-html-description": "Target group name for healthcheck",
+          "default": "\"\""
         },
         "instance_type": {
           "type": "string",
           "description": "Type of EC2 instance",
-          "x-intellij-html-description": "Type of EC2 instance"
+          "x-intellij-html-description": "Type of EC2 instance",
+          "default": "\"\""
         },
         "loadbalancers": {
           "items": {
-            "type": "string"
+            "type": "string",
+            "default": "\"\""
           },
           "type": "array",
           "description": "List of  load balancers",
@@ -296,11 +330,23 @@
         "region": {
           "type": "string",
           "description": "name",
-          "x-intellij-html-description": "name"
+          "x-intellij-html-description": "name",
+          "default": "\"\""
+        },
+        "scheduled_actions": {
+          "items": {
+            "type": "string",
+            "default": "\"\""
+          },
+          "type": "array",
+          "description": "List of scheduled actions",
+          "x-intellij-html-description": "List of scheduled actions",
+          "default": "[]"
         },
         "security_groups": {
           "items": {
-            "type": "string"
+            "type": "string",
+            "default": "\"\""
           },
           "type": "array",
           "description": "List of security group name",
@@ -310,11 +356,13 @@
         "ssh_key": {
           "type": "string",
           "description": "Key name of SSH access",
-          "x-intellij-html-description": "Key name of SSH access"
+          "x-intellij-html-description": "Key name of SSH access",
+          "default": "\"\""
         },
         "target_groups": {
           "items": {
-            "type": "string"
+            "type": "string",
+            "default": "\"\""
           },
           "type": "array",
           "description": "Target group list of load balancer",
@@ -330,24 +378,26 @@
         "vpc": {
           "type": "string",
           "description": "Name of VPC",
-          "x-intellij-html-description": "Name of VPC"
+          "x-intellij-html-description": "Name of VPC",
+          "default": "\"\""
         }
       },
       "additionalProperties": false,
       "preferredOrder": [
         "region",
-        "use_public_subnets",
         "instance_type",
         "ssh_key",
         "ami_id",
         "vpc",
-        "detailed_monitoring_enabled",
-        "security_groups",
         "healthcheck_load_balancer",
         "healthcheck_target_group",
+        "security_groups",
+        "scheduled_actions",
         "target_groups",
         "loadbalancers",
-        "availability_zones"
+        "availability_zones",
+        "use_public_subnets",
+        "detailed_monitoring_enabled"
       ],
       "description": "Region configuration",
       "x-intellij-html-description": "Region configuration"
@@ -357,22 +407,26 @@
         "adjustment_type": {
           "type": "string",
           "description": "Type of adjustment for autoscaling https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-scaling-simple-step.html",
-          "x-intellij-html-description": "Type of adjustment for autoscaling https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-scaling-simple-step.html"
+          "x-intellij-html-description": "Type of adjustment for autoscaling https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-scaling-simple-step.html",
+          "default": "\"\""
         },
         "cooldown": {
           "type": "integer",
           "description": "time between scaling actions",
-          "x-intellij-html-description": "time between scaling actions"
+          "x-intellij-html-description": "time between scaling actions",
+          "default": "0"
         },
         "name": {
           "type": "string",
           "description": "of scaling policy",
-          "x-intellij-html-description": "of scaling policy"
+          "x-intellij-html-description": "of scaling policy",
+          "default": "\"\""
         },
         "scaling_adjustment": {
           "type": "integer",
           "description": "Amount of adjustment for scaling",
-          "x-intellij-html-description": "Amount of adjustment for scaling"
+          "x-intellij-html-description": "Amount of adjustment for scaling",
+          "default": "0"
         }
       },
       "additionalProperties": false,
@@ -385,27 +439,60 @@
       "description": "Policy of scaling policy",
       "x-intellij-html-description": "Policy of scaling policy"
     },
+    "ScheduledAction": {
+      "properties": {
+        "capacity": {
+          "$ref": "#/definitions/Capacity",
+          "description": "of autoscaling group when action is triggered",
+          "x-intellij-html-description": "of autoscaling group when action is triggered"
+        },
+        "name": {
+          "type": "string",
+          "description": "of scheduled update action",
+          "x-intellij-html-description": "of scheduled update action",
+          "default": "\"\""
+        },
+        "recurrence": {
+          "type": "string",
+          "description": "The recurring schedule for the action, in Unix cron syntax format.",
+          "x-intellij-html-description": "The recurring schedule for the action, in Unix cron syntax format.",
+          "default": "\"\""
+        }
+      },
+      "additionalProperties": false,
+      "preferredOrder": [
+        "name",
+        "recurrence",
+        "capacity"
+      ],
+      "description": "Scheduled Action configurations",
+      "x-intellij-html-description": "Scheduled Action configurations"
+    },
     "SpotOptions": {
       "properties": {
         "block_duration_minutes": {
           "type": "integer",
           "description": "menas How long you want to use spot instance for sure",
-          "x-intellij-html-description": "menas How long you want to use spot instance for sure"
+          "x-intellij-html-description": "menas How long you want to use spot instance for sure",
+          "default": "0"
         },
         "instance_interruption_behavior": {
           "type": "string",
           "description": "Behavior when spot instance is interrupted",
-          "x-intellij-html-description": "Behavior when spot instance is interrupted"
+          "x-intellij-html-description": "Behavior when spot instance is interrupted",
+          "default": "\"\""
         },
         "max_price": {
           "type": "string",
           "description": "Maximum price of spot instance",
-          "x-intellij-html-description": "Maximum price of spot instance"
+          "x-intellij-html-description": "Maximum price of spot instance",
+          "default": "\"\""
         },
         "spot_instance_type": {
           "type": "string",
           "description": "Spot instance type",
-          "x-intellij-html-description": "Spot instance type"
+          "x-intellij-html-description": "Spot instance type",
+          "default": "\"\""
         }
       },
       "additionalProperties": false,
@@ -423,7 +510,8 @@
         "account": {
           "type": "string",
           "description": "Name of AWS Account",
-          "x-intellij-html-description": "Name of AWS Account"
+          "x-intellij-html-description": "Name of AWS Account",
+          "default": "\"\""
         },
         "alarms": {
           "items": {
@@ -436,7 +524,8 @@
         "assume_role": {
           "type": "string",
           "description": "IAM Role ARN for assume role",
-          "x-intellij-html-description": "IAM Role ARN for assume role"
+          "x-intellij-html-description": "IAM Role ARN for assume role",
+          "default": "\"\""
         },
         "autoscaling": {
           "items": {
@@ -468,12 +557,14 @@
         "env": {
           "type": "string",
           "description": "Environment of stack",
-          "x-intellij-html-description": "Environment of stack"
+          "x-intellij-html-description": "Environment of stack",
+          "default": "\"\""
         },
         "iam_instance_profile": {
           "type": "string",
           "description": "AWS IAM instance profile.",
-          "x-intellij-html-description": "AWS IAM instance profile."
+          "x-intellij-html-description": "AWS IAM instance profile.",
+          "default": "\"\""
         },
         "instance_market_options": {
           "$ref": "#/definitions/InstanceMarketOptions",
@@ -510,16 +601,19 @@
         "replacement_type": {
           "type": "string",
           "description": "Type of Replacement for deployment",
-          "x-intellij-html-description": "Type of Replacement for deployment"
+          "x-intellij-html-description": "Type of Replacement for deployment",
+          "default": "\"\""
         },
         "stack": {
           "type": "string",
           "description": "Name of stack",
-          "x-intellij-html-description": "Name of stack"
+          "x-intellij-html-description": "Name of stack",
+          "default": "\"\""
         },
         "tags": {
           "items": {
-            "type": "string"
+            "type": "string",
+            "default": "\"\""
           },
           "type": "array",
           "description": "Stack specific tags",
@@ -562,12 +656,14 @@
         "path": {
           "type": "string",
           "description": "of userdata file",
-          "x-intellij-html-description": "of userdata file"
+          "x-intellij-html-description": "of userdata file",
+          "default": "\"\""
         },
         "type": {
           "type": "string",
           "description": "of storage that contains userdata",
-          "x-intellij-html-description": "of storage that contains userdata"
+          "x-intellij-html-description": "of storage that contains userdata",
+          "default": "\"\""
         }
       },
       "additionalProperties": false,
@@ -583,7 +679,16 @@
         "name": {
           "type": "string",
           "description": "Application Name",
-          "x-intellij-html-description": "Application Name"
+          "x-intellij-html-description": "Application Name",
+          "default": "\"\""
+        },
+        "scheduled_actions": {
+          "items": {
+            "$ref": "#/definitions/ScheduledAction"
+          },
+          "type": "array",
+          "description": "List of scheduled actions",
+          "x-intellij-html-description": "List of scheduled actions"
         },
         "stacks": {
           "items": {
@@ -595,7 +700,8 @@
         },
         "tags": {
           "items": {
-            "type": "string"
+            "type": "string",
+            "default": "\"\""
           },
           "type": "array",
           "description": "Autoscaling tag list. This is attached to EC2 instance",
@@ -613,6 +719,7 @@
         "name",
         "userdata",
         "tags",
+        "scheduled_actions",
         "stacks"
       ],
       "description": "Yaml configuration from manifest file",

--- a/docs/content/ko/docs/References/commandline/_index.md
+++ b/docs/content/ko/docs/References/commandline/_index.md
@@ -14,6 +14,7 @@ weight: 10
 
 배포 정보 조회 및 수정:
 * [goployer status](#goployer-status) - 특정 배포 관련 정보 조회
+* [goployer update](#goployer-update) - 특정 배포에 대한 정보 업데이트
 
 <br>
 
@@ -24,7 +25,8 @@ weight: 10
 
 ## goployer init
 - 프로젝트 구조 생성
-```
+
+```bash
 Examples:
   # Minimum argument
   goployer init
@@ -32,8 +34,12 @@ Examples:
   # See log
   goployer init --log-level=debug
 
-Options:
-      --log-level string                Level of logging
+Flags:
+  -h, --help             help for init
+  -p, --profile string   Profile configuration of AWS
+
+Global Flags:
+  -v, --log-level string   Log level (debug, info, warn, error, fatal, panic) (default "warning")
 ```
 - 프로젝트 파일들은 현재 디렉토리에 생성됩니다.
   - manifests
@@ -43,7 +49,8 @@ Options:
 
 ## goployer add
 -  새로운 goployer 매니페스트 파일 생성
-```
+
+```bash
 Examples:
   # Minimum argument
   goployer add 
@@ -51,20 +58,96 @@ Examples:
   # You can specify application name from command
   goployer add hello
 
-Options:
-      --log-level string                Level of logging
+Flags:
+  -h, --help             help for add
+  -p, --profile string   Profile configuration of AWS
+
+Global Flags:
+  -v, --log-level string   Log level (debug, info, warn, error, fatal, panic) (default "warning")
 ```
 <br>
 
 ## goployer status
 -  특정 배포 관련 정보 조회
-```
+
+```bash
 Examples:
   # Minimum argument
+  goployer status hello 
+
+  # With region
   goployer status hello --region=ap-northeast-2
 
-Options:
-      --region string                  Region of autoscaling group
+Usage:
+  goployer status [flags]
+
+Flags:
+  -h, --help             help for status
+  -p, --profile string   Profile configuration of AWS
+      --region string    Region of autoscaling group
+
+Global Flags:
+  -v, --log-level string   Log level (debug, info, warn, error, fatal, panic) (default "warning")
+```
+
+```bash
+$ goployer status hello
+? Choose autoscaling group: hello-dev_apnortheast2-v003
+Name:           hello-dev_apnortheast2-v003
+Created Time:   2020-09-16 10:29:21.169 +0000 UTC
+
+📦 Capacity
+MINIMUM    DESIRED    MAXIMUM
+1          1          2
+
+🖥 Instance Statistics
+ ∙ t3.medium: 1
+
+⚓ Tags
+ ∙ Name=hello-dev_apnortheast2-v003
+ ∙ ansible-tags=all
+ ∙ app=hello
+ ∙ project=test
+ ∙ repo=hello-deploy
+ ∙ stack=_apnortheast2
+ ∙ stack-name=artd
+ ∙ test=test
+```
+<br>
+
+
+## goployer update
+-  특정 배포에 대한 정보 업데이트
+  - Capacity 조정: min/desired/max 값 변경
+
+```bash
+Examples:
+  # Minimum argument
+  # at least one of `--min, --max, --desired` is needed
+  goployer update hello --desired=1 --min=0 --max=1
+
+  # Auto apply without confirmation
+  goployer update hello --desired=1 --auto-apply
+
+  # Update with other options
+  goployer update hello --desired=1 --region=ap-northeast-2 --auto-apply --polling-interval=20s
+
+Usage:
+  goployer update name-prefix [flags] 
+
+Flags:
+      --auto-apply                  Apply command without confirmation from local terminal
+      --desired int                 Desired instance capacity you want to update with (default -1)
+  -h, --help                        help for update
+      --max int                     Maximum instance capacity you want to update with (default -1)
+      --min int                     Minimum instance capacity you want to update with (default -1)
+      --polling-interval duration   Time to interval for polling health check (default 60s) (default 1m0s)
+  -p, --profile string              Profile configuration of AWS
+      --region string               Region of autoscaling group
+      --timeout duration            Time to wait for deploy to finish before timing out (default 60m) (default 1h0m0s)
+
+Global Flags:
+  -v, --log-level string   Log level (debug, info, warn, error, fatal, panic) (default "warning")
 ```
 <br>
 
@@ -72,7 +155,6 @@ Options:
 -  새로운 어플리케이션 배포 실행
 
 ```
-
 Examples:
   # Minimum argument
   goployer deploy --manifest=configs/hello.yaml --stack=artd --region=ap-northeast-2
@@ -86,26 +168,30 @@ Examples:
   # Control polling interval for healthcheck
   goployer deploy --manifest=configs/hello.yaml --stack=artd --region=ap-northeast-2 --polling-interval=30s
 
-Options:
-  -m, --manifest string                 The manifest configuration file to use. (required)
-      --stack string                    stack that should be deployed.(required)
-      --manifest-s3-region string       Region of bucket containing the manifest configuration file to use. (required if –manifest starts with s3://)
+Flags:
       --ami string                      Amazon AMI to use.
       --ansible-extra-vars string       Extra variables for ansible
       --assume-role string              The Role ARN to assume into.
+      --auto-apply                      Apply command without confirmation from local terminal
       --disable-metrics                 Disable gathering metrics.
       --env string                      The environment that is being deployed into.
       --extra-tags string               Extra tags to add to autoscaling group tags
       --force-manifest-capacity         Force-apply the capacity of instances in the manifest file
-      --log-level string                Level of logging
+  -h, --help                            help for deploy
+  -m, --manifest string                 The manifest configuration file to use. (required)
+      --manifest-s3-region string       Region of bucket containing the manifest configuration file to use. (required if –manifest starts with s3://)
       --override-instance-type string   Instance Type to override
-      --polling-interval duration       Time to interval for polling health check (default 60s)
+      --polling-interval duration       Time to interval for polling health check (default 60s) (default 1m0s)
+  -p, --profile string                  Profile configuration of AWS
       --region string                   The region to deploy into, if undefined, then the deployment will run against all regions for the given environment.
       --release-notes string            Release note for the current deployment
       --release-notes-base64 string     Base64 encoded string of release note for the current deployment
       --slack-off                       Turn off slack alarm
-      --timeout duration                Time to wait for deploy to finish before timing out (default 60m)
-      --auto-apply                      Apply command without confirmation from local terminal
+      --stack string                    stack that should be deployed.(required)
+      --timeout duration                Time to wait for deploy to finish before timing out (default 60m) (default 1h0m0s)
+
+Global Flags:
+  -v, --log-level string   Log level (debug, info, warn, error, fatal, panic) (default "warning")
 ```
 <br>
 
@@ -114,8 +200,8 @@ Options:
 
 ## goployer delete
 - 이전 배포 버전 삭제
-```
 
+```bash
 Examples:
   # Minimum argument
   goployer delete --manifest=configs/hello.yaml --stack=artd --region=ap-northeast-2
@@ -126,17 +212,29 @@ Examples:
   # Control polling interval for healthcheck
   goployer delete --manifest=configs/hello.yaml --stack=artd --region=ap-northeast-2 --polling-interval=30s
 
-Options:
-  -m, --manifest string                 The manifest configuration file to use. (required)
-      --stack string                    stack that should be deployed.(required)
-      --manifest-s3-region string       Region of bucket containing the manifest configuration file to use. (required if –manifest starts with s3://)
-      --region string                   The region to deploy into, if undefined, then the deployment will run against all regions for the given environment.
+Flags:
+      --ami string                      Amazon AMI to use.
+      --ansible-extra-vars string       Extra variables for ansible
       --assume-role string              The Role ARN to assume into.
+      --auto-apply                      Apply command without confirmation from local terminal
       --disable-metrics                 Disable gathering metrics.
       --env string                      The environment that is being deployed into.
-      --log-level string                Level of logging
-      --polling-interval duration       Time to interval for polling health check (default 60s)
-      --timeout duration                Time to wait for deploy to finish before timing out (default 60m)
-      --auto-apply                      Apply command without confirmation from local terminal
+      --extra-tags string               Extra tags to add to autoscaling group tags
+      --force-manifest-capacity         Force-apply the capacity of instances in the manifest file
+  -h, --help                            help for delete
+  -m, --manifest string                 The manifest configuration file to use. (required)
+      --manifest-s3-region string       Region of bucket containing the manifest configuration file to use. (required if –manifest starts with s3://)
+      --override-instance-type string   Instance Type to override
+      --polling-interval duration       Time to interval for polling health check (default 60s) (default 1m0s)
+  -p, --profile string                  Profile configuration of AWS
+      --region string                   The region to deploy into, if undefined, then the deployment will run against all regions for the given environment.
+      --release-notes string            Release note for the current deployment
+      --release-notes-base64 string     Base64 encoded string of release note for the current deployment
+      --slack-off                       Turn off slack alarm
+      --stack string                    stack that should be deployed.(required)
+      --timeout duration                Time to wait for deploy to finish before timing out (default 60m) (default 1h0m0s)
+
+Global Flags:
+  -v, --log-level string   Log level (debug, info, warn, error, fatal, panic) (default "warning")
 ```
 <br>

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -322,6 +322,18 @@ func (b Builder) CheckValidation() error {
 					return fmt.Errorf("not available volume type : %s", block.VolumeType)
 				}
 
+				if block.VolumeType == "gp2" && block.VolumeSize < 1 {
+					return errors.New("volume size of gp2 type should be larger than 1GiB")
+				}
+
+				if tool.IsStringInArray(block.VolumeType, constants.IopsRequiredBlockType) && block.VolumeSize < 4 {
+					return errors.New("volume size of io1 and io2 type should be larger than 4GiB")
+				}
+
+				if tool.IsStringInArray(block.VolumeType, constants.IopsRequiredBlockType) && block.Iops < 100 {
+					return errors.New("iops of io1 and io2 type should be larger than 100")
+				}
+
 				if block.VolumeType == "st1" && block.VolumeSize < 500 {
 					return errors.New("volume size of st1 type should be larger than 500GiB")
 				}

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -292,12 +292,36 @@ func TestCheckValidationStack(t *testing.T) {
 		t.Errorf("validation failed: volume type")
 	}
 
+	b.Stacks[0].BlockDevices[0].VolumeType = "gp2"
+	b.Stacks[0].BlockDevices[0].VolumeSize = 0
+	if err := b.CheckValidation(); err == nil || err.Error() != "volume size of gp2 type should be larger than 1GiB" {
+		t.Errorf("validation failed: volume size - gp2")
+	}
+
 	b.Stacks[0].BlockDevices[0].VolumeType = "st1"
 	b.Stacks[0].BlockDevices[0].VolumeSize = 100
 	if err := b.CheckValidation(); err == nil || err.Error() != "volume size of st1 type should be larger than 500GiB" {
-		t.Errorf("validation failed: volume size")
+		t.Errorf("validation failed: volume size - st1")
 	}
-	b.Stacks[0].BlockDevices[0].VolumeSize = 500
+
+	b.Stacks[0].BlockDevices[0].VolumeType = "io1"
+	b.Stacks[0].BlockDevices[0].VolumeSize = 1
+	if err := b.CheckValidation(); err == nil || err.Error() != "volume size of io1 and io2 type should be larger than 4GiB" {
+		t.Errorf("validation failed: volume size - io1")
+	}
+
+	b.Stacks[0].BlockDevices[0].VolumeType = "io2"
+	b.Stacks[0].BlockDevices[0].VolumeSize = 1
+	if err := b.CheckValidation(); err == nil || err.Error() != "volume size of io1 and io2 type should be larger than 4GiB" {
+		t.Errorf("validation failed: volume size - io2")
+	}
+
+	b.Stacks[0].BlockDevices[0].VolumeSize = 4
+	b.Stacks[0].BlockDevices[0].Iops = 0
+	if err := b.CheckValidation(); err == nil || err.Error() != "iops of io1 and io2 type should be larger than 100" {
+		t.Errorf("validation failed: iops - io2")
+	}
+	b.Stacks[0].BlockDevices[0].Iops = 100
 
 	b.Stacks[0].BlockDevices = append(b.Stacks[0].BlockDevices, schemas.BlockDevice{
 		DeviceName: "/dev/xvda",

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -142,7 +142,10 @@ var (
 	AWSConfigPath = HomeDir() + "/.aws/config"
 
 	// AvailableBlockTypes is a list of available ebs block types
-	AvailableBlockTypes = []string{"io1", "gp2", "st1", "sc1"}
+	AvailableBlockTypes = []string{"io1", "io2", "gp2", "st1", "sc1"}
+
+	// IopsRequiredBlockType is a list of ebs type which requires iops
+	IopsRequiredBlockType = []string{"io1", "io2"}
 
 	// TimeFields is a list of time.Time field
 	TimeFields = []string{"timeout", "polling-interval"}

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -142,7 +142,7 @@ func (d Deployer) CheckTerminating(client aws.Client, target string, disableMetr
 
 	d.Logger.Info(fmt.Sprintf("Waiting for instance termination in asg %s", target))
 	if len(asgInfo.Instances) > 0 {
-		d.Logger.Info(fmt.Sprintf("%d instance found : %s", len(asgInfo.Instances), target))
+		d.Logger.Infof("%d instance found : %s", len(asgInfo.Instances), target)
 		d.Slack.SendSimpleMessage(fmt.Sprintf("Still %d instance found : %s", len(asgInfo.Instances), target), d.Stack.Env)
 
 		return false
@@ -163,22 +163,23 @@ func (d Deployer) CheckTerminating(client aws.Client, target string, disableMetr
 		d.Logger.Debugf("update status of %s is finished", target)
 	}
 
-	d.Logger.Debug(fmt.Sprintf("Start deleting launch templates in %s", target))
+	d.Logger.Debugf("Start deleting launch templates in %s", target)
 	if err := client.EC2Service.DeleteLaunchTemplates(target); err != nil {
 		d.Logger.Errorln(err.Error())
 		return false
 	}
-	d.Logger.Debug(fmt.Sprintf("Launch templates are deleted in %s\n", target))
+	d.Logger.Debugf("Launch templates are deleted in %s\n", target)
 
 	return true
 }
 
+// CleanAutoscalingSet cleans autoscaling group itself
 func (d Deployer) CleanAutoscalingSet(client aws.Client, target string) error {
-	d.Logger.Debug(fmt.Sprintf("Start deleting autoscaling group : %s", target))
+	d.Logger.Debugf("Start deleting autoscaling group : %s", target)
 	if err := client.EC2Service.DeleteAutoscalingSet(target); err != nil {
 		return err
 	}
-	d.Logger.Debug(fmt.Sprintf("Autoscaling group is deleted : %s", target))
+	d.Logger.Debugf("Autoscaling group is deleted : %s", target)
 
 	return nil
 }

--- a/pkg/schemas/config.go
+++ b/pkg/schemas/config.go
@@ -180,8 +180,11 @@ type BlockDevice struct {
 	// Size of volume
 	VolumeSize int64 `yaml:"volume_size"`
 
-	// Type of volume (gp2, io1, st1, sc1)
+	// Type of volume (gp2, io1, io2, st1, sc1)
 	VolumeType string `yaml:"volume_type"`
+
+	// IOPS for io1, io2 volume
+	Iops int64 `yaml:"iops"`
 }
 
 // Lifecycle Callback configuration

--- a/test/test_manifest.yaml
+++ b/test/test_manifest.yaml
@@ -322,7 +322,11 @@ stacks:
       min: 1
       max: 2
       desired: 1
-
+    block_devices:
+      - device_name: /dev/xvda
+        volume_size: 8
+        volume_type: "io2"
+        iops: 100
     autoscaling: *autoscaling_policy
     alarms: *autoscaling_alarms
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #86  <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
Support io2 volume type. And add alias of `log-level` with `v`. Any command could be used with `-v info|debug|warning...`. Default value of log is changed from info to warning.

**Additional**
- Modify documentations

**Release Note**
```
- support io2 volume type.
- add iops configuration in the manifest file for supporting iops-required volume type
- Add alias of `log-level` with `v`. Any command could be used with `-v info|debug|warning...`. Default value of log is changed from info to warning
```