### PR TITLE
add security group information to status command

### DIFF
--- a/cmd/goployer/cmd/status.go
+++ b/cmd/goployer/cmd/status.go
@@ -37,7 +37,7 @@ func NewStatusCommand() *cobra.Command {
 // funcStatus shows deployment status
 func funcStatus(ctx context.Context, _ io.Writer, args []string, mode string) error {
 	if len(args) != 1 {
-		return errors.New("usage: goployer status <application name> --region=<region ID>")
+		return errors.New("usage: goployer status <application name>")
 	}
 
 	return runWithoutExecutor(ctx, func() error {

--- a/configs/hello.yaml
+++ b/configs/hello.yaml
@@ -146,9 +146,6 @@ stacks:
       - device_name: /dev/xvda
         volume_size: 100
         volume_type: "gp2"
-      - device_name: /dev/xvdb
-        volume_type: "st1"
-        volume_size: 500
 
     # capacity
     capacity:
@@ -175,7 +172,7 @@ stacks:
       - region: ap-northeast-2
 
         # instance type
-        instance_type: t3.medium
+        instance_type: t3a.medium
 
         # ssh_key for instances
         ssh_key: test-master-key
@@ -252,7 +249,7 @@ stacks:
 
     regions:
       - region: ap-northeast-2
-        instance_type: t3.medium
+        instance_type: t3a.medium
         ssh_key: test-master-key
         ami_id: ami-01288945bd24ed49a
         use_public_subnets: true

--- a/pkg/aws/cloudwatch.go
+++ b/pkg/aws/cloudwatch.go
@@ -138,8 +138,6 @@ func (c CloudWatchClient) GetTargetGroupRequestStatistics(tgs []*string, startTi
 					return nil, err
 				}
 
-				fmt.Println(v)
-
 				if v != nil {
 					if _, ok := ret[tgName]; !ok {
 						ret[tgName] = map[string]float64{}
@@ -204,8 +202,6 @@ func (c CloudWatchClient) GetLoadBalancerRequestStatistics(loadbalancers []*stri
 				if err != nil {
 					return nil, err
 				}
-
-				fmt.Println(v)
 
 				if v != nil {
 					if _, ok := ret[lbName]; !ok {
@@ -281,8 +277,6 @@ func (c CloudWatchClient) GetOneDayStatisticsOfTargetGroup(tg string, startTime,
 		return nil, 0, nil
 	}
 
-	Logger.Infoln(result.MetricDataResults)
-
 	ret := map[string]float64{}
 	sum := float64(0)
 	for i, t := range result.MetricDataResults[0].Timestamps {
@@ -338,8 +332,6 @@ func (c CloudWatchClient) GetOneDayStatisticsOfLoadBalancer(lb string, startTime
 	if len(result.MetricDataResults) == 0 {
 		return nil, 0, nil
 	}
-
-	fmt.Println(result.MetricDataResults)
 
 	ret := map[string]float64{}
 	sum := float64(0)

--- a/pkg/aws/dynamodb.go
+++ b/pkg/aws/dynamodb.go
@@ -156,30 +156,6 @@ func (d DynamoDBClient) MakeRecord(stack, config, tags string, asg string, table
 
 	_, err := d.Client.PutItem(input)
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case dynamodb.ErrCodeConditionalCheckFailedException:
-				fmt.Println(dynamodb.ErrCodeConditionalCheckFailedException, aerr.Error())
-			case dynamodb.ErrCodeProvisionedThroughputExceededException:
-				fmt.Println(dynamodb.ErrCodeProvisionedThroughputExceededException, aerr.Error())
-			case dynamodb.ErrCodeResourceNotFoundException:
-				fmt.Println(dynamodb.ErrCodeResourceNotFoundException, aerr.Error())
-			case dynamodb.ErrCodeItemCollectionSizeLimitExceededException:
-				fmt.Println(dynamodb.ErrCodeItemCollectionSizeLimitExceededException, aerr.Error())
-			case dynamodb.ErrCodeTransactionConflictException:
-				fmt.Println(dynamodb.ErrCodeTransactionConflictException, aerr.Error())
-			case dynamodb.ErrCodeRequestLimitExceeded:
-				fmt.Println(dynamodb.ErrCodeRequestLimitExceeded, aerr.Error())
-			case dynamodb.ErrCodeInternalServerError:
-				fmt.Println(dynamodb.ErrCodeInternalServerError, aerr.Error())
-			default:
-				fmt.Println(aerr.Error())
-			}
-		} else {
-			// Print the error, cast err to awserr.Error to get the Code and
-			// Message from an error.
-			fmt.Println(err.Error())
-		}
 		return err
 	}
 

--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -70,6 +70,34 @@ func (e EC2Client) GetMatchingAutoscalingGroup(name string) (*autoscaling.Group,
 	return asgGroup, nil
 }
 
+// GetMatchingLaunchTemplate returns information of launch template with matched ID
+func (e EC2Client) GetMatchingLaunchTemplate(ltID string) (*ec2.LaunchTemplateVersion, error) {
+	input := &ec2.DescribeLaunchTemplateVersionsInput{
+		LaunchTemplateId: aws.String(ltID),
+	}
+
+	ret, err := e.Client.DescribeLaunchTemplateVersions(input)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret.LaunchTemplateVersions[0], nil
+}
+
+// GetSecurityGroupDetails returns detailed information for security group
+func (e EC2Client) GetSecurityGroupDetails(sgIds []*string) ([]*ec2.SecurityGroup, error) {
+	input := &ec2.DescribeSecurityGroupsInput{
+		GroupIds: sgIds,
+	}
+
+	result, err := e.Client.DescribeSecurityGroups(input)
+	if err != nil {
+		return nil, err
+	}
+
+	return result.SecurityGroups, nil
+}
+
 // Delete All Launch Configurations belongs to the autoscaling group
 func (e EC2Client) DeleteLaunchConfigurations(asgName string) error {
 	lcs := getAllLaunchConfigurations(e.AsClient, []*autoscaling.LaunchConfiguration{}, nil)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -122,6 +122,9 @@ const (
 
 	// DefaultEnableStats is whether or not to enable gathering stats
 	DefaultEnableStats = true
+
+	// ALL means ALL as string
+	ALL = "ALL"
 )
 
 var (

--- a/pkg/runner/rurnner.go
+++ b/pkg/runner/rurnner.go
@@ -474,7 +474,17 @@ func (r Runner) Status() error {
 		return err
 	}
 
-	inspector.StatusSummary = inspector.SetStatusSummary(group)
+	launchTemplateInfo, err := inspector.GetLaunchTemplateInformation(*group.LaunchTemplate.LaunchTemplateId)
+	if err != nil {
+		return err
+	}
+
+	securityGroups, err := inspector.GetSecurityGroupsInformation(launchTemplateInfo.LaunchTemplateData.SecurityGroupIds)
+	if err != nil {
+		return err
+	}
+
+	inspector.StatusSummary = inspector.SetStatusSummary(group, securityGroups)
 
 	if err := inspector.Print(); err != nil {
 		return err

--- a/pkg/tool/color.go
+++ b/pkg/tool/color.go
@@ -74,6 +74,8 @@ func DecorateAttr(attrString, message string) string {
 		return "⚓ "
 	case "instance_statistics":
 		return "🖥 "
+	case "security groups":
+		return "🚥 "
 	case "message":
 		return "💌 "
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #104  <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
Add security group information in `goployer status` 
This could help users to find the ingress/egress information with api call 

Sample result
```
$ ./goployer status hello
? Choose autoscaling group: hello-dev_apnortheast2-v001
Name:           hello-dev_apnortheast2-v001
Created Time:   2020-09-17 07:06:58.908 +0000 UTC

📦 Capacity
MINIMUM    DESIRED    MAXIMUM
1          1          2

🖥 Instance Statistics
 ∙ t3a.medium: 1

⚓ Tags
 ∙ Name=hello-dev_apnortheast2-v001
 ∙ ansible-tags=all
 ∙ app=hello
 ∙ project=test
 ∙ repo=hello-deploy
 ∙ stack=_apnortheast2
 ∙ stack-name=artd
 ∙ test=test

🚥 Inbound Rules
ID                        PROTOCOL   FROM    TO      SOURCE                 DESCRIPTION
 ∙ sg-0d2c6874708e46db0   tcp        80      80      sg-066e526d93370530e   Port Open for hello
 ∙ sg-0630dcb93f961fa8f   tcp        10080   10080   10.0.0.0/8             inbound rule for jmx exporter
 ∙ sg-0630dcb93f961fa8f   tcp        9100    9100    10.0.0.0/8             inbound rule for node exporter
 ∙ sg-0630dcb93f961fa8f   tcp        9100    9100    10.1.0.0/16

🚥 Outbound Rules
ID                        PROTOCOL   FROM   TO     SOURCE      DESCRIPTION
 ∙ sg-0d2c6874708e46db0   ALL        ALL    ALL    0.0.0.0/0   Internal outbound traffic
 ∙ sg-0630dcb93f961fa8f   tcp        80     80     0.0.0.0/0   https any outbound
 ∙ sg-0630dcb93f961fa8f   tcp        443    443    0.0.0.0/0   https any outbound
 ∙ sg-0630dcb93f961fa8f   tcp        9200   9200   0.0.0.0/0   ElasticSearch any outbound
 ∙ sg-0630dcb93f961fa8f   tcp        9092   9092   0.0.0.0/0   kafka any outbound
```

**Release Note**
```
- Add security group information in `goployer status` command
```