### PR TITLE
hotfix api test configuration error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ out
 build
 venv
 .DS_Store
-configs
+configs/*

--- a/configs/hello.yaml
+++ b/configs/hello.yaml
@@ -98,7 +98,7 @@ stacks:
     ebs_optimized: true
 
     # API Test Enabled
-    api_test_enabled: true
+    #api_test_enabled: false
 
     # instance_market_options is for spot usage
     # You only can choose spot as market_type.
@@ -270,18 +270,3 @@ stacks:
           - ap-northeast-2a
           - ap-northeast-2b
           - ap-northeast-2c
-
-api_test_template:
-  name: api-test
-  duration: 5s
-  request_per_second: 10
-  apis:
-    - method: GET
-      url: https://hello-wedapne2.weplydev.io
-    - method: POST
-      url: https://hello-wedapne2.weplydev.io/adduser
-      body:
-        - id=198355
-        - username=Gwonsoo
-        - test=test
-

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -117,7 +117,10 @@ func NewBuilder(config *schemas.Config) (Builder, error) {
 func (b Builder) SetManifestConfig() Builder {
 	awsConfig, stacks, apiTestTemplate := ParsingManifestFile(b.Config.Manifest)
 	b.AwsConfig = awsConfig
-	b.APITestTemplate = apiTestTemplate
+
+	if apiTestTemplate != nil {
+		b.APITestTemplate = apiTestTemplate
+	}
 
 	return b.SetStacks(stacks)
 }
@@ -604,7 +607,7 @@ func buildStructFromYaml(yamlFile []byte) (schemas.AWSConfig, []schemas.Stack, *
 
 	Stacks := yamlConfig.Stacks
 
-	return awsConfig, Stacks, &yamlConfig.APITestTemplate
+	return awsConfig, Stacks, yamlConfig.APITestTemplate
 }
 
 // argumentParsing parses arguments from command

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -443,7 +443,7 @@ func TestCheckValidationStack(t *testing.T) {
 	}
 	b.APITestTemplate.RequestPerSecond = 5
 
-	b.APITestTemplate.APIs = []schemas.APIManifest{
+	b.APITestTemplate.APIs = []*schemas.APIManifest{
 		{
 			Method: "TEST",
 		},

--- a/pkg/schemas/config.go
+++ b/pkg/schemas/config.go
@@ -65,7 +65,7 @@ type YamlConfig struct {
 	Stacks []Stack `yaml:"stacks"`
 
 	// API Test configuration
-	APITestTemplate APITestTemplate `yaml:"api_test_template"`
+	APITestTemplate *APITestTemplate `yaml:"api_test_template,omitempty"`
 }
 
 type AWSConfig struct {
@@ -368,24 +368,24 @@ type LifecycleHookSpecification struct {
 // Templates for API Test
 type APITestTemplate struct {
 	// Name of test template
-	Name string `yaml:"name"`
+	Name string `yaml:"name,omitempty"`
 
 	// Duration of api test which means how long you want to test for API test
-	Duration time.Duration `yaml:"duration"`
+	Duration time.Duration `yaml:"duration,omitempty"`
 
 	// Request per second to call
-	RequestPerSecond int `yaml:"request_per_second"`
+	RequestPerSecond int `yaml:"request_per_second,omitempty"`
 
-	APIs []APIManifest `yaml:"apis"`
+	APIs []*APIManifest `yaml:"apis,omitempty"`
 }
 
 // Configuration of API test
 type APIManifest struct {
 	// Method of API Call: [ GET, POST, PUT ... ]
-	Method string `yaml:"method"`
+	Method string `yaml:"method,omitempty"`
 
 	// Full URL of API
-	URL string `yaml:"url"`
+	URL string `yaml:"url,omitempty"`
 
 	// list of body value as JSON format
 	Body []string `yaml:"body,omitempty"`

--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -160,6 +160,10 @@ func (s Slack) CreateTitleSection(text string) *slack.SectionBlock {
 
 // SendAPITestResultMessage sends API test message
 func (s Slack) SendAPITestResultMessage(metrics []schemas.MetricResult) error {
+	if !s.ValidClient() {
+		return nil
+	}
+
 	if len(s.WebhookURL) > 0 {
 		return s.SendAPITestResultMessageWithWebHook(metrics)
 	}


### PR DESCRIPTION
API Test configuration error occurred when there is no `api_test_templates` 

This could have an effect on all manifest files.