### PR TITLE
add instance restart

### DIFF
--- a/cmd/goployer/cmd/cmd.go
+++ b/cmd/goployer/cmd/cmd.go
@@ -72,6 +72,7 @@ You can find more information in https://goployer.dev`,
 	rootCmd.AddCommand(NewStatusCommand())
 	rootCmd.AddCommand(NewAddCommand())
 	rootCmd.AddCommand(NewUpdateCommand())
+	rootCmd.AddCommand(NewRefreshCommand())
 
 	rootCmd.PersistentFlags().StringVarP(&v, "log-level", "v", constants.DefaultLogLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
 

--- a/cmd/goployer/cmd/flag.go
+++ b/cmd/goployer/cmd/flag.go
@@ -50,12 +50,13 @@ var zeroTimeout = 0 * time.Minute
 var zeroPollingInterval = 0 * time.Second
 
 var flagKey = map[string]string{
-	"deploy": "deploySet",
-	"delete": "fullSet",
-	"init":   "initSet",
-	"status": "statusSet",
-	"update": "updateSet",
-	"add":    "addSet",
+	"deploy":  "deploySet",
+	"delete":  "fullSet",
+	"init":    "initSet",
+	"status":  "statusSet",
+	"update":  "updateSet",
+	"add":     "addSet",
+	"refresh": "refreshSet",
 }
 
 var CommonFlagRegistry = []Flag{
@@ -414,6 +415,50 @@ var FlagRegistry = map[string][]Flag{
 			Usage:         "Desired instance capacity you want to update with",
 			Value:         aws.Int(-1),
 			DefValue:      -1,
+			FlagAddMethod: "IntVar",
+		},
+		{
+			Name:          "polling-interval",
+			Usage:         "Time to interval for polling health check (default 60s)",
+			Value:         &zeroPollingInterval,
+			DefValue:      pollingInterval,
+			FlagAddMethod: "DurationVar",
+		},
+		{
+			Name:          "timeout",
+			Usage:         "Time to wait for deploy to finish before timing out (default 60m)",
+			Value:         &zeroTimeout,
+			DefValue:      timeout,
+			FlagAddMethod: "DurationVar",
+		},
+	},
+	"refreshSet": {
+		{
+			Name:          "region",
+			Usage:         "Region of autoscaling group",
+			Value:         aws.String(constants.EmptyString),
+			DefValue:      constants.EmptyString,
+			FlagAddMethod: "StringVar",
+		},
+		{
+			Name:          "auto-apply",
+			Usage:         "Apply command without confirmation from local terminal",
+			Value:         aws.Bool(false),
+			DefValue:      false,
+			FlagAddMethod: "BoolVar",
+		},
+		{
+			Name:          "instance-warmup",
+			Usage:         "How much time it takes a newly launched instance to be ready to use.",
+			Value:         aws.Int(constants.DefaultInstanceWarmup),
+			DefValue:      constants.DefaultInstanceWarmup,
+			FlagAddMethod: "IntVar",
+		},
+		{
+			Name:          "min-healthy-percentage",
+			Usage:         "At least this percentage of the desired capacity of the Auto Scaling group must remain healthy during this operation to allow it to continue.",
+			Value:         aws.Int(constants.DefaultMinHealthyPercentage),
+			DefValue:      constants.DefaultMinHealthyPercentage,
 			FlagAddMethod: "IntVar",
 		},
 		{

--- a/cmd/goployer/cmd/refresh.go
+++ b/cmd/goployer/cmd/refresh.go
@@ -1,0 +1,59 @@
+/*
+copyright 2020 the Goployer authors
+
+licensed under the apache license, version 2.0 (the "license");
+you may not use this file except in compliance with the license.
+you may obtain a copy of the license at
+
+    http://www.apache.org/licenses/license-2.0
+
+unless required by applicable law or agreed to in writing, software
+distributed under the license is distributed on an "as is" basis,
+without warranties or conditions of any kind, either express or implied.
+see the license for the specific language governing permissions and
+limitations under the license.
+*/
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DevopsArtFactory/goployer/pkg/runner"
+)
+
+// Create new refresh command
+func NewRefreshCommand() *cobra.Command {
+	return NewCmd("refresh").
+		WithDescription("Refresh autoscaling group instances").
+		SetFlags().
+		RunWithArgs(funcRefresh)
+}
+
+// funcRefresh refreshes autoscaling group instances with new template without creating new autoscaling group
+func funcRefresh(ctx context.Context, _ io.Writer, args []string, mode string) error {
+	if len(args) != 1 {
+		return errors.New("usage: goployer refresh <application name> [ --region <region-id> ]")
+	}
+
+	return runWithoutExecutor(ctx, func() error {
+		//Create new builder
+		builderSt, err := runner.SetupBuilder(mode)
+		if err != nil {
+			return err
+		}
+
+		builderSt.Config.Application = args[0]
+
+		//Start runner
+		if err := runner.Start(builderSt, mode); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -84,6 +84,12 @@ const (
 	// DefaultHealthcheckGracePeriod is the default healthcheck grace period
 	DefaultHealthcheckGracePeriod = 300
 
+	// DefaultInstanceWarmup is the default duration for instance warmup
+	DefaultInstanceWarmup = 300
+
+	// DefaultMinHealthyPercentage is the default value of minimum healthy instance percentage for refresh
+	DefaultMinHealthyPercentage = 90
+
 	// S3Prefix is prefix of s3 URL
 	S3Prefix = "s3://"
 

--- a/pkg/inspector/inspector.go
+++ b/pkg/inspector/inspector.go
@@ -298,6 +298,7 @@ func (i Inspector) Update() error {
 	return nil
 }
 
+// GenerateStack generates stack configuration for update
 func (i Inspector) GenerateStack(region string, group *autoscaling.Group) schemas.Stack {
 	s := schemas.Stack{
 		Stack:    "update-stack",

--- a/pkg/refresh/refresh.go
+++ b/pkg/refresh/refresh.go
@@ -1,0 +1,126 @@
+/*
+copyright 2020 the Goployer authors
+
+licensed under the apache license, version 2.0 (the "license");
+you may not use this file except in compliance with the license.
+you may obtain a copy of the license at
+
+    http://www.apache.org/licenses/license-2.0
+
+unless required by applicable law or agreed to in writing, software
+distributed under the license is distributed on an "as is" basis,
+without warranties or conditions of any kind, either express or implied.
+see the license for the specific language governing permissions and
+limitations under the license.
+*/
+
+package refresh
+
+import (
+	"errors"
+	"html/template"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/sirupsen/logrus"
+
+	"github.com/DevopsArtFactory/goployer/pkg/aws"
+	"github.com/DevopsArtFactory/goployer/pkg/constants"
+	"github.com/DevopsArtFactory/goployer/pkg/templates"
+	"github.com/DevopsArtFactory/goployer/pkg/tool"
+)
+
+type Refresher struct {
+	AWSClient   aws.Client
+	TargetGroup *autoscaling.Group
+	RefreshID   *string
+	Info        *autoscaling.InstanceRefresh
+}
+
+// New creates new Refresher
+func New(region string) Refresher {
+	return Refresher{
+		AWSClient: aws.BootstrapServices(region, constants.EmptyString),
+	}
+}
+
+// SetTarget sets target autoscaling group
+func (r *Refresher) SetTarget(group *autoscaling.Group) {
+	r.TargetGroup = group
+}
+
+// StartRefresh starts instance refresh
+func (r *Refresher) StartRefresh(instanceWarmup, minHealthyPercentage int64) error {
+	logrus.Debugf("Start to trigger instance refresh")
+	logrus.Debugf("Instance Warmup time: %ds", instanceWarmup)
+	logrus.Debugf("Minimum healthy instance percentage: %d%", minHealthyPercentage)
+	id, err := r.AWSClient.EC2Service.StartInstanceRefresh(r.TargetGroup.AutoScalingGroupName, instanceWarmup, minHealthyPercentage)
+	if err != nil {
+		return err
+	}
+
+	r.RefreshID = id
+	logrus.Debugf("Instance Refresh is initiated: %s", *id)
+
+	return nil
+}
+
+// DescribeRefreshStatus retrieves status information of instance refresh
+func (r *Refresher) DescribeRefreshStatus() error {
+	info, err := r.AWSClient.EC2Service.DescribeInstanceRefreshes(r.TargetGroup.AutoScalingGroupName, r.RefreshID)
+	if err != nil {
+		return err
+	}
+
+	r.Info = info
+	r.RefreshID = info.InstanceRefreshId
+	logrus.Debugf("Current status: %s / %s", *info.InstanceRefreshId, *info.Status)
+
+	return nil
+}
+
+// StatusCheck starts status check
+func (r *Refresher) StatusCheck(pollingInterval, timeout time.Duration) error {
+	logrus.Debug("Start to check instance refresh status")
+	startTime := time.Now()
+	logrus.Debugf("Current time: %s / Timeout: %s", startTime, timeout)
+	logrus.Debugf("Polling interval: %s", pollingInterval)
+	for {
+		isTimeout, _ := tool.CheckTimeout(startTime.Unix(), timeout)
+		if isTimeout {
+			return errors.New("timeout limit exceeded")
+		}
+
+		if err := r.DescribeRefreshStatus(); err != nil {
+			return err
+		}
+
+		if tool.IsStringInArray(*r.Info.Status, []string{"Successful", "Cancelled", "Failed"}) {
+			logrus.Debugf("Instance refresh is finished because the status is %s", *r.Info.Status)
+			break
+		}
+
+		time.Sleep(pollingInterval)
+	}
+
+	return nil
+}
+
+// PrintResult prints result of refresh work
+func (r *Refresher) PrintResult() error {
+	var data = struct {
+		Target  autoscaling.Group
+		Summary autoscaling.InstanceRefresh
+	}{
+		Target:  *r.TargetGroup,
+		Summary: *r.Info,
+	}
+
+	funcMap := template.FuncMap{
+		"decorate": tool.DecorateAttr,
+	}
+
+	t := template.Must(template.New("Instance Refresh Result").Funcs(funcMap).Parse(templates.InstanceRefreshStatusTemplate))
+
+	return tool.PrintTemplate(data, t)
+}

--- a/pkg/schemas/config.go
+++ b/pkg/schemas/config.go
@@ -37,6 +37,8 @@ type Config struct { // Do not add comments for this struct
 	Min                    int64 `json:"min"`
 	Max                    int64 `json:"max"`
 	Desired                int64 `json:"desired"`
+	InstanceWarmup         int64 `json:"instance_warmup"`
+	MinHealthyPercentage   int64 `json:"min_healthy_percentage"`
 	StartTimestamp         int64
 	Timeout                time.Duration `json:"timeout"`
 	PollingInterval        time.Duration `json:"polling_interval"`

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -183,3 +183,10 @@ TOTAL	MEAN	MAX	P95	P99
 {{- end }}
 
 `
+
+const InstanceRefreshStatusTemplate = `{{decorate "bold" "Name"}}:	{{ .Target.AutoScalingGroupName }}
+{{decorate "bold" "Instance Refresh ID"}}:	{{ .Summary.InstanceRefreshId }}
+{{decorate "bold" "Start Time"}}:	{{ .Summary.StartTime }}
+{{decorate "bold" "End Time"}}:	{{ .Summary.EndTime }}
+{{decorate "bold" "Status"}}:	{{ .Summary.Status }}
+`


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #120  <!-- tracking issues that this PR will close -->

**Description**
Instance Refresh is the feature which changes instances of autoscaling without changing capacity manually. This helps when user wants to change instance with the new one or move VM to other place.

**Usage**
```
❯ goployer refresh hello -v debug --auto-apply --instance-warmup=120 --polling-interval=20s
INFO[0000] Goployer {Version: BuildDate: GitCommit: GitTreeState: Platform:darwin/amd64} 
DEBU[0000] Start to trigger instance refresh            
DEBU[0000] Instance Warmup time: 120s                   
DEBU[0000] Minimum healthy instance percentage: 90s     
DEBU[0003] Start to check instance refresh status       
DEBU[0003] Current time: 2020-11-18 11:05:01.878251 +0900 KST m=+3.880962992 / Timeout: 1h0m0s 
DEBU[0003] Polling interval: 20s                        
DEBU[0003] Current status: c47db010-18c8-4221-b117-xxxxx / InProgress 
DEBU[0024] Current status: c47db010-18c8-4221-b117-xxxxx / InProgress 
DEBU[0044] Current status: c47db010-18c8-4221-b117-xxxxx / InProgress 
...
DEBU[0367] Current status: c47db010-18c8-4221-b117-xxxxx / InProgress 
DEBU[0388] Current status: c47db010-18c8-4221-b117-xxxxx / InProgress 
DEBU[0408] Current status: c47db010-18c8-4221-b117-xxxxx / Successful 
DEBU[0408] Instance refresh is finished because the status is Successful 
Name:                  hello-artd_apne2-v001
Instance Refresh ID:   c47db010-18c8-4221-b117-xxxxx
Start Time:            2020-11-18 02:03:49 &#43;0000 UTC
End Time:              2020-11-18 02:11:30 &#43;0000 UTC
Status:                Successful

```