### PR TITLE
add rolling update deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 venv
 .DS_Store
 configs/*
+.env

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= amd64
 BUILD_DIR ?= ./out
@@ -183,8 +184,7 @@ api-test:
 .PHONY: coverage
 coverage: $(BUILD_DIR)
 	@ go test -count=1 -race -cover -short -timeout=90s -coverprofile=out/coverage.txt -coverpkg="./pkg/...,./hack..." $(TEST_PACKAGES)
-	@- curl -s https://codecov.io/bash > $(BUILD_DIR)/upload_coverage && bash $(BUILD_DIR)/upload_coverage
-
+	@- curl -s https://codecov.io/bash > $(BUILD_DIR)/upload_coverage && bash $(BUILD_DIR)/upload_coverage -t $(COVERAGE_TOKEN)
 .PHONY: linters
 linters: $(BUILD_DIR)
 	@ ./hack/linters.sh

--- a/examples/manifests/basic-example.yaml
+++ b/examples/manifests/basic-example.yaml
@@ -2,7 +2,7 @@
 name: hello
 userdata:
   type: local
-  path: scripts/userdata.sh
+  path: examples/scripts/userdata.sh
 
 autoscaling: &autoscaling_policy
   - name: scale_out
@@ -56,9 +56,9 @@ stacks:
         volume_type: "st1"
         volume_size: 500
     capacity:
-      min: 1
-      max: 2
-      desired: 1
+      min: 3
+      max: 3
+      desired: 3
     autoscaling: *autoscaling_policy
     alarms: *autoscaling_alarms
     lifecycle_callbacks:

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -145,10 +145,12 @@ func (b Builder) SetStacks(stacks []schemas.Stack) Builder {
 		}
 	}
 
-	for i := range stacks {
+	for i, stack := range stacks {
 		if b.Config.PollingInterval > 0 {
 			stacks[i].PollingInterval = b.Config.PollingInterval
 		}
+
+		stacks[i].ReplacementType = strings.ToLower(stack.ReplacementType)
 	}
 
 	b.Stacks = stacks

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -48,6 +48,9 @@ const (
 	// InServiceStatus means status in service
 	InServiceStatus = "InService"
 
+	// PendingStatus means pending status
+	PendingStatus = "Pending"
+
 	// TestString is "test"
 	TestString = "test"
 
@@ -163,8 +166,9 @@ const (
 	CanaryMark = "canary"
 
 	// Deployment Methods
-	BlueGreenDeployment = "BlueGreen"
-	CanaryDeployment    = "Canary"
+	BlueGreenDeployment     = "bluegreen"
+	CanaryDeployment        = "canary"
+	RollingUpdateDeployment = "rollingupdate"
 )
 
 var (

--- a/pkg/deployer/bluegreen.go
+++ b/pkg/deployer/bluegreen.go
@@ -46,25 +46,8 @@ func NewBlueGreen(h *helper.DeployerHelper) *BlueGreen {
 		awsClients = append(awsClients, aws.BootstrapServices(region.Region, h.Stack.AssumeRole))
 	}
 
-	d := Deployer{
-		Mode:              h.Stack.ReplacementType,
-		Logger:            h.Logger,
-		AwsConfig:         h.AwsConfig,
-		AWSClients:        awsClients,
-		APITestTemplate:   h.APITestTemplates,
-		AsgNames:          map[string]string{},
-		PrevAsgs:          map[string][]string{},
-		PrevInstances:     map[string][]string{},
-		PrevInstanceCount: map[string]schemas.Capacity{},
-		PrevVersions:      map[string][]int{},
-		SecurityGroup:     map[string]*string{},
-		CanaryFlag:        map[string]bool{},
-		LatestAsg:         map[string]string{},
-		Stack:             h.Stack,
-		Slack:             h.Slack,
-		Collector:         h.Collector,
-		StepStatus:        helper.InitStartStatus(),
-	}
+	d := InitDeploymentConfiguration(h, awsClients)
+
 	return &BlueGreen{
 		Deployer: &d,
 	}

--- a/pkg/deployer/rollingupdate.go
+++ b/pkg/deployer/rollingupdate.go
@@ -1,0 +1,330 @@
+/*
+copyright 2020 the Goployer authors
+
+licensed under the apache license, version 2.0 (the "license");
+you may not use this file except in compliance with the license.
+you may obtain a copy of the license at
+
+    http://www.apache.org/licenses/license-2.0
+
+unless required by applicable law or agreed to in writing, software
+distributed under the license is distributed on an "as is" basis,
+without warranties or conditions of any kind, either express or implied.
+see the license for the specific language governing permissions and
+limitations under the license.
+*/
+
+package deployer
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/DevopsArtFactory/goployer/pkg/aws"
+	"github.com/DevopsArtFactory/goployer/pkg/builder"
+	"github.com/DevopsArtFactory/goployer/pkg/constants"
+	"github.com/DevopsArtFactory/goployer/pkg/helper"
+	"github.com/DevopsArtFactory/goployer/pkg/schemas"
+	"github.com/DevopsArtFactory/goployer/pkg/tool"
+)
+
+type RollingUpdate struct {
+	PrevTargetGroups            map[string][]string
+	TargetGroups                map[string][]*string
+	PrevHealthCheckTargetGroups map[string]string
+	LoadBalancer                map[string]string
+	LBSecurityGroup             map[string]*string
+	*Deployer
+}
+
+// NewRollingUpdate creates new rolling-update deployment deployer
+func NewRollingUpdate(h *helper.DeployerHelper) *RollingUpdate {
+	var awsClients []aws.Client
+	for _, region := range h.Stack.Regions {
+		if len(h.Region) > 0 && h.Region != region.Region {
+			h.Logger.Debugf("skip creating aws clients in %s region", region.Region)
+			continue
+		}
+		awsClients = append(awsClients, aws.BootstrapServices(region.Region, h.Stack.AssumeRole))
+	}
+
+	d := InitDeploymentConfiguration(h, awsClients)
+
+	return &RollingUpdate{
+		PrevHealthCheckTargetGroups: map[string]string{},
+		PrevTargetGroups:            map[string][]string{},
+		TargetGroups:                map[string][]*string{},
+		LoadBalancer:                map[string]string{},
+		LBSecurityGroup:             map[string]*string{},
+		Deployer:                    &d,
+	}
+}
+
+// GetDeployer returns canary deployer
+func (r *RollingUpdate) GetDeployer() *Deployer {
+	return r.Deployer
+}
+
+// CheckPreviousResources checks if there is any previous version of autoscaling group
+func (r *RollingUpdate) CheckPreviousResources(config schemas.Config) error {
+	err := r.Deployer.CheckPrevious(config)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Deploy runs deployments with canary approach
+func (r *RollingUpdate) Deploy(config schemas.Config) error {
+	if !r.StepStatus[constants.StepCheckPrevious] {
+		return nil
+	}
+	r.Logger.Infof("Deploy Mode is %s", r.Mode)
+
+	//Get LocalFileProvider
+	r.LocalProvider = builder.SetUserdataProvider(r.Stack.Userdata, r.AwsConfig.Userdata)
+	for _, region := range r.Stack.Regions {
+		if config.Region != "" && config.Region != region.Region {
+			r.Logger.Debugf("This region is skipped by user : %s", region.Region)
+			continue
+		}
+
+		err := r.Deployer.Deploy(config, region)
+		if err != nil {
+			return err
+		}
+	}
+
+	r.StepStatus[constants.StepDeploy] = true
+	return nil
+}
+
+// HealthChecking does health checking for canary deployment
+func (r *RollingUpdate) HealthChecking(config schemas.Config) error {
+	healthy := false
+
+	for !healthy {
+		r.Logger.Debugf("Start Timestamp: %d, timeout: %s", config.StartTimestamp, config.Timeout)
+		isTimeout, _ := tool.CheckTimeout(config.StartTimestamp, config.Timeout)
+		if isTimeout {
+			return fmt.Errorf("timeout has been exceeded : %.0f minutes", config.Timeout.Minutes())
+		}
+
+		isDone, err := r.Deployer.HealthChecking(config)
+		if err != nil {
+			return errors.New("error happened while health checking")
+		}
+
+		if isDone {
+			healthy = true
+		} else {
+			time.Sleep(config.PollingInterval)
+		}
+	}
+
+	return nil
+}
+
+// FinishAdditionalWork processes additional work for the new deployment
+func (r *RollingUpdate) FinishAdditionalWork(config schemas.Config) error {
+	if !r.StepStatus[constants.StepDeploy] {
+		return nil
+	}
+
+	skipped := false
+	if len(config.Region) > 0 && !CheckRegionExist(config.Region, r.Stack.Regions) {
+		skipped = true
+	}
+
+	if !skipped {
+		for _, region := range r.Stack.Regions {
+			if config.Region != "" && config.Region != region.Region {
+				r.Logger.Debugf("This region is skipped by user : %s", region.Region)
+				continue
+			}
+
+			if err := r.CompleteRollingUpdate(config, region); err != nil {
+				return err
+			}
+		}
+
+		if err := r.DoCommonAdditionalWork(config); err != nil {
+			return err
+		}
+	}
+
+	r.Logger.Debugln("Finish additional works")
+	r.StepStatus[constants.StepAdditionalWork] = true
+	return nil
+}
+
+// TriggerLifecycleCallbacks runs lifecycle callbacks before cleaning.
+func (r *RollingUpdate) TriggerLifecycleCallbacks(config schemas.Config) error {
+	if !r.StepStatus[constants.StepAdditionalWork] {
+		return nil
+	}
+	if config.CompleteCanary {
+		r.StepStatus[constants.StepTriggerLifecycleCallback] = true
+		return nil
+	}
+	return r.Deployer.TriggerLifecycleCallbacks(config)
+}
+
+// CleanPreviousVersion cleans previous version of autoscaling group or canary target group
+func (r *RollingUpdate) CleanPreviousVersion(config schemas.Config) error {
+	if !r.StepStatus[constants.StepTriggerLifecycleCallback] {
+		return nil
+	}
+	r.Logger.Debugf("Skip CleanPreviousVersion because instance(s) is(are) already deleted: %s", r.Mode)
+
+	r.StepStatus[constants.StepCleanPreviousVersion] = true
+	return nil
+}
+
+// GatherMetrics gathers the whole metrics from deployer
+func (r *RollingUpdate) GatherMetrics(config schemas.Config) error {
+	if !r.StepStatus[constants.StepCleanChecking] {
+		return nil
+	}
+	if config.DisableMetrics {
+		return nil
+	}
+
+	if len(config.Region) > 0 {
+		if !CheckRegionExist(config.Region, r.Stack.Regions) {
+			return nil
+		}
+	}
+
+	if !config.CompleteCanary {
+		r.Logger.Debug("Skip gathering metrics because canary is now applied")
+		return nil
+	}
+
+	if err := r.Deployer.StartGatheringMetrics(config); err != nil {
+		return err
+	}
+
+	r.StepStatus[constants.StepGatherMetrics] = true
+	return nil
+}
+
+// RunAPITest tries to run API Test
+func (r *RollingUpdate) RunAPITest(config schemas.Config) error {
+	if !r.StepStatus[constants.StepGatherMetrics] {
+		return nil
+	}
+
+	if !config.CompleteCanary {
+		r.Logger.Debug("Skip API test because canary is now applied")
+		return nil
+	}
+
+	err := r.Deployer.RunAPITest(config)
+	if err != nil {
+		return err
+	}
+
+	r.StepStatus[constants.StepRunAPI] = true
+	return nil
+}
+
+// CleanChecking checks Termination status
+func (r *RollingUpdate) CleanChecking(config schemas.Config) error {
+	if !r.StepStatus[constants.StepCleanPreviousVersion] {
+		return nil
+	}
+	done := false
+
+	for !done {
+		isTimeout, _ := tool.CheckTimeout(config.StartTimestamp, config.Timeout)
+		if isTimeout {
+			return fmt.Errorf("timeout has been exceeded : %.0f minutes", config.Timeout.Minutes())
+		}
+
+		isDone, err := r.Deployer.CleanChecking(config)
+		if err != nil {
+			return errors.New("error happened while health checking")
+		}
+
+		if isDone {
+			done = true
+		} else {
+			r.Logger.Info("All stacks are not ready to be terminated... Please waiting...")
+			time.Sleep(config.PollingInterval)
+		}
+	}
+
+	r.StepStatus[constants.StepCleanChecking] = true
+	return nil
+}
+
+// CompleteRollingUpdate processes the whole process of rolling update
+func (r *RollingUpdate) CompleteRollingUpdate(config schemas.Config, region schemas.RegionConfig) error {
+	latestASG := r.LatestAsg[region.Region]
+	asgDetail, err := r.Deployer.DescribeAutoScalingGroup(latestASG, region.Region)
+	if err != nil {
+		return err
+	}
+
+	if asgDetail == nil {
+		return fmt.Errorf("no autoscaling group information retrieved. Please check autoscaling group resource: %s", latestASG)
+	}
+
+	appliedCapacity, err := r.Deployer.DecideCapacity(config.ForceManifestCapacity, false, region.Region)
+	if err != nil {
+		return err
+	}
+
+	targetCapacity := r.Deployer.CompareWithCurrentCapacity(config.ForceManifestCapacity, region.Region)
+
+	previousFinished := false
+	for !IsFinishedRollingUpdate(appliedCapacity, targetCapacity) || !previousFinished {
+		if !previousFinished {
+			previousFinished, err = r.Deployer.ReducePreviousAutoScalingGroupCapacity(region.Region, 1)
+			if err != nil {
+				return err
+			}
+		}
+
+		if err := RetrieveNextCapacity(&appliedCapacity, targetCapacity); err != nil {
+			return err
+		}
+
+		r.Logger.Debugf("Rolling update of autoscaling group: min - %d, desired - %d, max - %d", appliedCapacity.Min, appliedCapacity.Desired, appliedCapacity.Max)
+		if err := r.Deployer.ResizingAutoScalingGroup(r.AsgNames[region.Region], region.Region, appliedCapacity); err != nil {
+			return err
+		}
+
+		// settings for health checking
+		r.AppliedCapacity = &appliedCapacity
+
+		if err := r.HealthChecking(config); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RetrieveNextCapacity add one capacity at a time
+func RetrieveNextCapacity(capacity *schemas.Capacity, targetCapacity schemas.Capacity) error {
+	if targetCapacity.Min > capacity.Min {
+		capacity.Min++
+	}
+
+	if targetCapacity.Desired > capacity.Desired {
+		capacity.Desired++
+	}
+
+	if targetCapacity.Max > capacity.Max {
+		capacity.Max++
+	}
+	return nil
+}
+
+// IsFinishedRollingUpdate checks if rolling update is done or not
+func IsFinishedRollingUpdate(current schemas.Capacity, target schemas.Capacity) bool {
+	return current.Min == target.Min && current.Desired == target.Desired && current.Max == target.Max
+}

--- a/pkg/refresh/refresh.go
+++ b/pkg/refresh/refresh.go
@@ -53,7 +53,7 @@ func (r *Refresher) SetTarget(group *autoscaling.Group) {
 func (r *Refresher) StartRefresh(instanceWarmup, minHealthyPercentage int64) error {
 	logrus.Debugf("Start to trigger instance refresh")
 	logrus.Debugf("Instance Warmup time: %ds", instanceWarmup)
-	logrus.Debugf("Minimum healthy instance percentage: %d%", minHealthyPercentage)
+	logrus.Debugf("Minimum healthy instance percentage: %d", minHealthyPercentage)
 	id, err := r.AWSClient.EC2Service.StartInstanceRefresh(r.TargetGroup.AutoScalingGroupName, instanceWarmup, minHealthyPercentage)
 	if err != nil {
 		return err

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -680,6 +680,8 @@ func getDeployer(logger *Logger.Logger, stack schemas.Stack, awsConfig schemas.A
 		d = deployer.NewBlueGreen(&h)
 	case constants.CanaryDeployment:
 		d = deployer.NewCanary(&h)
+	case constants.RollingUpdateDeployment:
+		d = deployer.NewRollingUpdate(&h)
 	}
 
 	return d


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

Now, goployer supports rolling update deployment!!

Anyone can use this by setting replacement_type to "RollingUpdate"

Rolling update will create one instance only first and start rolling update with previous instances.