### PR TITLE
add rolling update instance count

### DIFF
--- a/examples/manifests/rollingupdate-example.yaml
+++ b/examples/manifests/rollingupdate-example.yaml
@@ -1,0 +1,84 @@
+---
+name: hello
+userdata:
+  type: local
+  path: examples/scripts/userdata.sh
+
+autoscaling: &autoscaling_policy
+  - name: scale_out
+    adjustment_type: ChangeInCapacity
+    scaling_adjustment: 1
+    cooldown: 60
+  - name: scale_in
+    adjustment_type: ChangeInCapacity
+    scaling_adjustment: -1
+    cooldown: 180
+
+alarms: &autoscaling_alarms
+  - name: scale_out_on_util
+    namespace: AWS/EC2
+    metric: CPUUtilization
+    statistic: Average
+    comparison: GreaterThanOrEqualToThreshold
+    threshold: 50
+    period: 120
+    evaluation_periods: 2
+    alarm_actions:
+      - scale_out
+  - name: scale_in_on_util
+    namespace: AWS/EC2
+    metric: CPUUtilization
+    statistic: Average
+    comparison: LessThanOrEqualToThreshold
+    threshold: 30
+    period: 300
+    evaluation_periods: 3
+    alarm_actions:
+      - scale_in
+
+# Tags should be like "key=value"
+tags:
+  - project=test
+  - repo=hello-deploy
+
+stacks:
+  - stack: artd
+    polling_interval: 30s
+    account: dev
+    env: dev
+    replacement_type: RollingUpdate
+    rolling_update_instance_count: 3
+    iam_instance_profile: 'app-hello-profile'
+    ebs_optimized: true
+    block_devices:
+      - device_name: /dev/xvda
+        volume_size: 10
+        volume_type: gp3
+    capacity:
+      min: 10
+      max: 15
+      desired: 10
+    autoscaling: *autoscaling_policy
+    alarms: *autoscaling_alarms
+    lifecycle_callbacks:
+      pre_terminate_past_cluster:
+        - service hello stop
+
+    regions:
+      - region: ap-northeast-2
+        instance_type: t3.medium
+        ssh_key: test-master-key
+        ami_id: ami-01288945bd24ed49a
+        use_public_subnets: true
+        vpc: vpc-artd_apnortheast2
+        detailed_monitoring_enabled: false
+        security_groups:
+          - hello-artd_apnortheast2
+          - default-artd_apnortheast2
+        healthcheck_target_group: hello-artdapne2-ext
+        availability_zones:
+          - ap-northeast-2a
+          - ap-northeast-2b
+          - ap-northeast-2c
+        target_groups:
+          - hello-artdapne2-ext

--- a/pkg/deployer/bluegreen.go
+++ b/pkg/deployer/bluegreen.go
@@ -206,19 +206,6 @@ func (b *BlueGreen) CleanChecking(config schemas.Config) error {
 	return nil
 }
 
-// CheckRegionExist checks if target region is really in regions described in manifest file
-func CheckRegionExist(target string, regions []schemas.RegionConfig) bool {
-	regionExists := false
-	for _, region := range regions {
-		if region.Region == target {
-			regionExists = true
-			break
-		}
-	}
-
-	return regionExists
-}
-
 // GatherMetrics gathers the whole metrics from deployer
 func (b *BlueGreen) GatherMetrics(config schemas.Config) error {
 	if config.DisableMetrics {

--- a/pkg/deployer/canary.go
+++ b/pkg/deployer/canary.go
@@ -1068,7 +1068,7 @@ func (c *Canary) CompleteCanaryDeployment(config schemas.Config, region schemas.
 		return err
 	}
 
-	appliedCapacity, err := c.Deployer.DecideCapacity(config.ForceManifestCapacity, config.CompleteCanary, region.Region)
+	appliedCapacity, err := c.Deployer.DecideCapacity(config.ForceManifestCapacity, config.CompleteCanary, region.Region, len(c.PrevAsgs[region.Region]), c.Stack.RollingUpdateInstanceCount)
 	if err != nil {
 		return err
 	}

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -48,12 +48,12 @@ func TestDeployer_DecideCapacity(t *testing.T) {
 
 	forceManifestCapacity := false
 	completeCanary := false
-	if out, _ := deployer.DecideCapacity(forceManifestCapacity, completeCanary, constants.DefaultRegion); out != prev {
+	if out, _ := deployer.DecideCapacity(forceManifestCapacity, completeCanary, constants.DefaultRegion, len(deployer.PrevAsgs[constants.DefaultRegion]), deployer.Stack.RollingUpdateInstanceCount); out != prev {
 		t.Error("BlueGreen capacity setting error")
 	}
 
 	forceManifestCapacity = true
-	if out, _ := deployer.DecideCapacity(forceManifestCapacity, completeCanary, constants.DefaultRegion); out != intended {
+	if out, _ := deployer.DecideCapacity(forceManifestCapacity, completeCanary, constants.DefaultRegion, len(deployer.PrevAsgs[constants.DefaultRegion]), deployer.Stack.RollingUpdateInstanceCount); out != intended {
 		t.Error("BlueGreen capacity setting error with forceManifestCapacity")
 	}
 
@@ -63,19 +63,19 @@ func TestDeployer_DecideCapacity(t *testing.T) {
 		Desired: 1,
 	}
 	deployer.Mode = constants.CanaryDeployment
-	if out, _ := deployer.DecideCapacity(forceManifestCapacity, completeCanary, constants.DefaultRegion); out != canaryIntended {
+	if out, _ := deployer.DecideCapacity(forceManifestCapacity, completeCanary, constants.DefaultRegion, len(deployer.PrevAsgs[constants.DefaultRegion]), deployer.Stack.RollingUpdateInstanceCount); out != canaryIntended {
 		t.Error("Canary capacity setting error")
 	}
 
 	completeCanary = true
 	forceManifestCapacity = false
 	deployer.Mode = constants.CanaryDeployment
-	if out, _ := deployer.DecideCapacity(forceManifestCapacity, completeCanary, constants.DefaultRegion); out != prev {
+	if out, _ := deployer.DecideCapacity(forceManifestCapacity, completeCanary, constants.DefaultRegion, len(deployer.PrevAsgs[constants.DefaultRegion]), deployer.Stack.RollingUpdateInstanceCount); out != prev {
 		t.Error("Canary capacity setting error with completeCanary")
 	}
 
 	forceManifestCapacity = true
-	if out, _ := deployer.DecideCapacity(forceManifestCapacity, completeCanary, constants.DefaultRegion); out != intended {
+	if out, _ := deployer.DecideCapacity(forceManifestCapacity, completeCanary, constants.DefaultRegion, len(deployer.PrevAsgs[constants.DefaultRegion]), deployer.Stack.RollingUpdateInstanceCount); out != intended {
 		t.Error("Canary capacity setting error with forceManifestCapacity")
 	}
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -59,7 +59,7 @@ func NewRunner(newBuilder builder.Builder, mode string) (Runner, error) {
 		Slacker: slack.NewSlackClient(newBuilder.Config.SlackOff),
 	}
 
-	if checkManifestCommands(mode) {
+	if checkBuilderConfigurationNeeded(mode) {
 		newRunner.Collector = collector.NewCollector(newBuilder.MetricConfig, newBuilder.Config.AssumeRole)
 	}
 
@@ -82,7 +82,7 @@ func SetupBuilder(mode string) (builder.Builder, error) {
 		return builder.Builder{}, err
 	}
 
-	if !checkManifestCommands(mode) {
+	if !checkBuilderConfigurationNeeded(mode) {
 		return builderSt, nil
 	}
 
@@ -204,7 +204,7 @@ func AddManifest(args []string) error {
 
 // Start function is the starting point of all processes.
 func Start(builderSt builder.Builder, mode string) error {
-	if checkManifestCommands(mode) {
+	if checkBuilderConfigurationNeeded(mode) {
 		// Check validation of configurations
 		if err := builderSt.CheckValidation(); err != nil {
 			return err
@@ -719,8 +719,8 @@ func askApplicationName() (string, error) {
 	return answer, nil
 }
 
-// checkManifestCommands checks if mode is needed to run manifest validation
-func checkManifestCommands(mode string) bool {
+// checkBuilderConfigurationNeeded checks if mode needs configuration settings like builder, metrics etc
+func checkBuilderConfigurationNeeded(mode string) bool {
 	return tool.IsStringInArray(mode, []string{"deploy", "delete"})
 }
 

--- a/pkg/schemas/config.go
+++ b/pkg/schemas/config.go
@@ -121,6 +121,9 @@ type Stack struct {
 	// Type of Replacement for deployment
 	ReplacementType string `yaml:"replacement_type"`
 
+	// Instance count per round in rolling update replacement type
+	RollingUpdateInstanceCount int64 `yaml:"rolling_update_instance_count"`
+
 	// Userdata configuration for stack deployment
 	Userdata Userdata `yaml:"userdata,omitempty"`
 
@@ -300,7 +303,7 @@ type RegionConfig struct {
 	// Type of EC2 instance
 	InstanceType string `yaml:"instance_type"`
 
-	// Key name of SSH access
+	// Key name ofSSH access
 	SSHKey string `yaml:"ssh_key"`
 
 	// Amazon AMI ID


### PR DESCRIPTION
Add rolling update instance count option in order for users to run rolling update with custom instance count.

Users can use `rolling_update_instance_count` in stack configuration. If replacement_type is not `RollingUpdate`, then this configuration will be ignored. If it is and `rolling_update_instance_count` is null, then `1` will be applied.

