### PR TITLE
add termination_delay_rate option

### DIFF
--- a/docs/content/en/schemas/schema.json
+++ b/docs/content/en/schemas/schema.json
@@ -86,6 +86,10 @@
       "description": "Templates for API Test",
       "x-intellij-html-description": "Templates for API Test"
     },
+    "AWSConfig": {
+      "description": "AWS Related Configurations except for stack",
+      "x-intellij-html-description": "AWS Related Configurations except for stack"
+    },
     "AlarmConfigs": {
       "properties": {
         "alarm_actions": {
@@ -456,6 +460,16 @@
           "x-intellij-html-description": "Target group list of load balancer",
           "default": "[]"
         },
+        "termination_policies": {
+          "items": {
+            "type": "string",
+            "default": "\"\""
+          },
+          "type": "array",
+          "description": "List of termination policies of autoscaling group. Default will be applied if nothing is specified",
+          "x-intellij-html-description": "List of termination policies of autoscaling group. Default will be applied if nothing is specified",
+          "default": "[]"
+        },
         "use_public_subnets": {
           "type": "boolean",
           "description": "Whether or not to use public subnets",
@@ -483,6 +497,7 @@
         "target_groups",
         "loadbalancers",
         "availability_zones",
+        "termination_policies",
         "use_public_subnets",
         "detailed_monitoring_enabled"
       ],
@@ -703,6 +718,12 @@
           "x-intellij-html-description": "Type of Replacement for deployment",
           "default": "\"\""
         },
+        "rolling_update_instance_count": {
+          "type": "integer",
+          "description": "Instance count per round in rolling update replacement type",
+          "x-intellij-html-description": "Instance count per round in rolling update replacement type",
+          "default": "0"
+        },
         "stack": {
           "type": "string",
           "description": "Name of stack",
@@ -719,6 +740,12 @@
           "x-intellij-html-description": "Stack specific tags",
           "default": "[]"
         },
+        "termination_delay_rate": {
+          "type": "integer",
+          "description": "Percentage of instances to terminate in one batch during termination process in BlueGreen deployment for termination delay",
+          "x-intellij-html-description": "Percentage of instances to terminate in one batch during termination process in BlueGreen deployment for termination delay",
+          "default": "0"
+        },
         "userdata": {
           "$ref": "#/definitions/Userdata",
           "description": "configuration for stack deployment",
@@ -731,6 +758,8 @@
         "account",
         "env",
         "replacement_type",
+        "termination_delay_rate",
+        "rolling_update_instance_count",
         "userdata",
         "iam_instance_profile",
         "tags",

--- a/examples/manifests/basic-example.yaml
+++ b/examples/manifests/basic-example.yaml
@@ -46,6 +46,7 @@ stacks:
     account: dev
     env: dev
     replacement_type: BlueGreen
+    termination_delay_rate: 50
     iam_instance_profile: app-hello-profile
     ebs_optimized: true
     block_devices:
@@ -56,9 +57,9 @@ stacks:
         volume_type: "st1"
         volume_size: 500
     capacity:
-      min: 3
-      max: 3
-      desired: 3
+      min: 4
+      max: 4
+      desired: 4
     autoscaling: *autoscaling_policy
     alarms: *autoscaling_alarms
     lifecycle_callbacks:
@@ -74,7 +75,7 @@ stacks:
         vpc: vpc-artd_apnortheast2
         detailed_monitoring_enabled: false
         security_groups:
-          - hello-artd_apnortheast2
+          #- hello-artd_apnortheast2
           - default-artd_apnortheast2
         healthcheck_target_group: hello-artdapne2-ext
         availability_zones:

--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -404,7 +404,7 @@ func (e EC2Client) GetSecurityGroupList(vpc string, sgList []string) ([]*string,
 			return nil, err
 		}
 
-		//If it matches 0 or more than 1, it is wrong
+		// if it matches 0 or more than 1, it is wrong
 		if len(result.SecurityGroups) != 1 {
 			var matched []string
 			for _, s := range result.SecurityGroups {

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -372,7 +372,7 @@ func (b Builder) CheckValidation() error {
 					}
 
 					if len(l.RoleARN) > 0 && len(l.NotificationTargetARN) == 0 {
-						return fmt.Errorf("notification_target_arn is needed if role_arn is not empty : %s", l.LifecycleHookName)
+						return fmt.Errorf("notification_target_arn is needed if role_arn is not empty: %s", l.LifecycleHookName)
 					}
 
 					if l.HeartbeatTimeout == 0 {
@@ -388,13 +388,23 @@ func (b Builder) CheckValidation() error {
 					}
 
 					if len(l.RoleARN) > 0 && len(l.NotificationTargetARN) == 0 {
-						return fmt.Errorf("notification_target_arn is needed if role_arn is not empty  : %s", l.LifecycleHookName)
+						return fmt.Errorf("notification_target_arn is needed if role_arn is not empty: %s", l.LifecycleHookName)
 					}
 
 					if l.HeartbeatTimeout == 0 {
 						Logger.Warnf("you didn't specify the heartbeat timeout. you might have to wait too long time.")
 					}
 				}
+			}
+		}
+
+		if stack.ReplacementType == constants.BlueGreenDeployment {
+			if stack.TerminationDelayRate > 100 {
+				return fmt.Errorf("termination_delay_rate cannot exceed 100. It should be 0<=x<=100")
+			}
+
+			if stack.TerminationDelayRate < 0 {
+				return fmt.Errorf("termination_delay_rate cannot be negative. It should be 0<=x<=100")
 			}
 		}
 

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -404,10 +404,22 @@ func TestCheckValidationStack(t *testing.T) {
 			},
 		},
 	}
-	if err := b.CheckValidation(); err == nil || err.Error() != "notification_target_arn is needed if role_arn is not empty : test" {
+	if err := b.CheckValidation(); err == nil || err.Error() != "notification_target_arn is needed if role_arn is not empty: test" {
 		t.Errorf("validation failed: lifecycle hook role")
 	}
 	b.Stacks[0].LifecycleHooks = nil
+
+	b.Stacks[0].ReplacementType = constants.BlueGreenDeployment
+	b.Stacks[0].TerminationDelayRate = 101
+	if err := b.CheckValidation(); err == nil || err.Error() != "termination_delay_rate cannot exceed 100. It should be 0<=x<=100" {
+		t.Errorf("validation failed: termination delay rate exceed 100")
+	}
+
+	b.Stacks[0].TerminationDelayRate = -1
+	if err := b.CheckValidation(); err == nil || err.Error() != "termination_delay_rate cannot be negative. It should be 0<=x<=100" {
+		t.Errorf("validation failed: termination delay rate negative")
+	}
+	b.Stacks[0].TerminationDelayRate = 0
 
 	b.Stacks[0].Regions = []schemas.RegionConfig{
 		{

--- a/pkg/deployer/canary.go
+++ b/pkg/deployer/canary.go
@@ -745,7 +745,7 @@ func (c *Canary) CleanPreviousCanaryResources(region schemas.RegionConfig, compl
 		}
 
 		c.Logger.Debugf("[Resizing] target autoscaling group : %s", *asg.AutoScalingGroupName)
-		if err := c.ResizingAutoScalingGroupToZero(client, *asg.AutoScalingGroupName); err != nil {
+		if err := c.ResizingAutoScalingGroupCount(client, *asg.AutoScalingGroupName, 0); err != nil {
 			c.Logger.Errorf(err.Error())
 		}
 		c.Logger.Debugf("Resizing autoscaling group finished: %s", *asg.AutoScalingGroupName)

--- a/pkg/schemas/config.go
+++ b/pkg/schemas/config.go
@@ -121,6 +121,9 @@ type Stack struct {
 	// Type of Replacement for deployment
 	ReplacementType string `yaml:"replacement_type"`
 
+	// Percentage of instances to terminate in one batch during termination process in BlueGreen deployment for termination delay
+	TerminationDelayRate int64 `yaml:"termination_delay_rate"`
+
 	// Instance count per round in rolling update replacement type
 	RollingUpdateInstanceCount int64 `yaml:"rolling_update_instance_count"`
 
@@ -303,7 +306,7 @@ type RegionConfig struct {
 	// Type of EC2 instance
 	InstanceType string `yaml:"instance_type"`
 
-	// Key name ofSSH access
+	// Key name of SSH access
 	SSHKey string `yaml:"ssh_key"`
 
 	// Amazon AMI ID


### PR DESCRIPTION
Add `termination_delay_rate` options for BlueGreen deployment. 
This is helpful when users want to deploy with BlueGreen strategy but terminate instances gradually in order to keep stateful status.

If instance count is 10 and `termination_delay_rate` is 20, then first it provisions 10 more instances for Blue status. After all of instances are healthy, then reduce the instance count of Green status. At this time, goployer will reduce only 2 instances ( 20% of 10 instances) and check if those instances are successfully terminated.