### PR TITLE
add deployonly type

### DIFF
--- a/examples/manifests/deployonly-example.yaml
+++ b/examples/manifests/deployonly-example.yaml
@@ -1,0 +1,83 @@
+---
+name: hello
+userdata:
+  type: local
+  path: examples/scripts/userdata.sh
+
+autoscaling: &autoscaling_policy
+  - name: scale_out
+    adjustment_type: ChangeInCapacity
+    scaling_adjustment: 1
+    cooldown: 60
+  - name: scale_in
+    adjustment_type: ChangeInCapacity
+    scaling_adjustment: -1
+    cooldown: 180
+
+alarms: &autoscaling_alarms
+  - name: scale_out_on_util
+    namespace: AWS/EC2
+    metric: CPUUtilization
+    statistic: Average
+    comparison: GreaterThanOrEqualToThreshold
+    threshold: 50
+    period: 120
+    evaluation_periods: 2
+    alarm_actions:
+      - scale_out
+  - name: scale_in_on_util
+    namespace: AWS/EC2
+    metric: CPUUtilization
+    statistic: Average
+    comparison: LessThanOrEqualToThreshold
+    threshold: 30
+    period: 300
+    evaluation_periods: 3
+    alarm_actions:
+      - scale_in
+
+tags:
+  - project=test
+  - repo=hello-deploy
+
+stacks:
+  - stack: artd
+    polling_interval: 30s
+    account: dev
+    env: dev
+    replacement_type: DeployOnly
+    termination_delay_rate: 50
+    iam_instance_profile: app-hello-profile
+    ebs_optimized: true
+    block_devices:
+      - device_name: /dev/xvda
+        volume_size: 15
+        volume_type: "gp2"
+      - device_name: /dev/xvdb
+        volume_type: "st1"
+        volume_size: 500
+    capacity:
+      min: 1
+      max: 1
+      desired: 1
+    autoscaling: *autoscaling_policy
+    alarms: *autoscaling_alarms
+    lifecycle_callbacks:
+      pre_terminate_past_cluster:
+        - service hello stop
+
+    regions:
+      - region: ap-northeast-2
+        instance_type: t3.medium
+        ssh_key: test-master-key
+        ami_id: ami-01288945bd24ed49a
+        use_public_subnets: true
+        vpc: vpc-artd_apnortheast2
+        detailed_monitoring_enabled: false
+        security_groups:
+          #- hello-artd_apnortheast2
+          - default-artd_apnortheast2
+        availability_zones:
+          - ap-northeast-2a
+          - ap-northeast-2b
+          - ap-northeast-2c

--- a/pkg/aws/elbv2.go
+++ b/pkg/aws/elbv2.go
@@ -55,6 +55,11 @@ func getElbClientFn(session client.ConfigProvider, region string, creds *credent
 
 // GetTargetGroupARNs returns arn list of target groups
 func (e ELBV2Client) GetTargetGroupARNs(targetGroups []string) ([]*string, error) {
+	// Return nil if there is no target group.
+	if len(targetGroups) == 0 {
+		return nil, nil
+	}
+
 	tgWithDetails, err := e.DescribeTargetGroups(aws.StringSlice(targetGroups))
 	if err != nil {
 		return nil, err

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -169,6 +169,7 @@ const (
 	BlueGreenDeployment     = "bluegreen"
 	CanaryDeployment        = "canary"
 	RollingUpdateDeployment = "rollingupdate"
+	DeployOnly              = "deployonly"
 )
 
 var (

--- a/pkg/deployer/canary.go
+++ b/pkg/deployer/canary.go
@@ -421,6 +421,10 @@ func (c *Canary) AttachToOriginalTargetGroups(config schemas.Config) error {
 			return err
 		}
 
+		if targetGroupARNs == nil {
+			return fmt.Errorf("there is no target group specified")
+		}
+
 		c.Logger.Debugf("Attach autoscaling group to original target groups: %s", c.AsgNames[region.Region])
 		if err := client.EC2Service.AttachAsgToTargetGroups(c.AsgNames[region.Region], targetGroupARNs); err != nil {
 			return err

--- a/pkg/deployer/deployonly.go
+++ b/pkg/deployer/deployonly.go
@@ -1,0 +1,216 @@
+/*
+copyright 2020 the Goployer authors
+
+licensed under the apache license, version 2.0 (the "license");
+you may not use this file except in compliance with the license.
+you may obtain a copy of the license at
+
+    http://www.apache.org/licenses/license-2.0
+
+unless required by applicable law or agreed to in writing, software
+distributed under the license is distributed on an "as is" basis,
+without warranties or conditions of any kind, either express or implied.
+see the license for the specific language governing permissions and
+limitations under the license.
+*/
+
+package deployer
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	Logger "github.com/sirupsen/logrus"
+
+	"github.com/DevopsArtFactory/goployer/pkg/aws"
+	"github.com/DevopsArtFactory/goployer/pkg/builder"
+	"github.com/DevopsArtFactory/goployer/pkg/constants"
+	"github.com/DevopsArtFactory/goployer/pkg/helper"
+	"github.com/DevopsArtFactory/goployer/pkg/schemas"
+	"github.com/DevopsArtFactory/goployer/pkg/tool"
+)
+
+type DeployOnly struct {
+	*Deployer
+}
+
+// NewDeployOnly creates new DeployOnly deployment deployer
+func NewDeployOnly(h *helper.DeployerHelper) *DeployOnly {
+	awsClients := []aws.Client{}
+	for _, region := range h.Stack.Regions {
+		if len(h.Region) > 0 && h.Region != region.Region {
+			Logger.Debugf("skip creating aws clients in %s region", region.Region)
+			continue
+		}
+		awsClients = append(awsClients, aws.BootstrapServices(region.Region, h.Stack.AssumeRole))
+	}
+
+	d := InitDeploymentConfiguration(h, awsClients)
+
+	return &DeployOnly{
+		Deployer: &d,
+	}
+}
+
+// GetDeployer returns Deployer struct
+func (d *DeployOnly) GetDeployer() *Deployer {
+	return d.Deployer
+}
+
+// CheckPreviousResources checks if there is any previous version of autoscaling group
+func (d *DeployOnly) CheckPreviousResources(config schemas.Config) error {
+	err := d.Deployer.CheckPrevious(config)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Deploy function
+func (d *DeployOnly) Deploy(config schemas.Config) error {
+	if !d.StepStatus[constants.StepCheckPrevious] {
+		return nil
+	}
+
+	d.Logger.Info("Deploy Mode is " + d.Mode)
+
+	//Get LocalFileProvider
+	d.LocalProvider = builder.SetUserdataProvider(d.Stack.Userdata, d.AwsConfig.Userdata)
+
+	for _, region := range d.Stack.Regions {
+		//Region check
+		//If region id is passed from command line, then deployer will deploy in that region only.
+		if config.Region != "" && config.Region != region.Region {
+			d.Logger.Debug("This region is skipped by user : " + region.Region)
+			continue
+		}
+
+		err := d.Deployer.Deploy(config, region)
+		if err != nil {
+			return err
+		}
+	}
+
+	d.StepStatus[constants.StepDeploy] = true
+	return nil
+}
+
+// HealthChecking does health checking for d.ue-green deployment
+func (d *DeployOnly) HealthChecking(_ schemas.Config) error {
+	// No health checking is needed
+	Logger.Info("Skip health check because this is DeployOnly mode")
+
+	// sleep 30 seconds for a new instance to be ready
+	time.Sleep(30 * time.Second)
+
+	return nil
+}
+
+// FinishAdditionalWork processes additional work for the new deployment
+func (d *DeployOnly) FinishAdditionalWork(config schemas.Config) error {
+	if !d.StepStatus[constants.StepDeploy] {
+		return nil
+	}
+
+	skipped := false
+	if len(config.Region) > 0 && !CheckRegionExist(config.Region, d.Stack.Regions) {
+		skipped = true
+	}
+
+	if !skipped {
+		if err := d.DoCommonAdditionalWork(config); err != nil {
+			return err
+		}
+	}
+
+	d.Logger.Debug("Finish additional works.")
+	d.StepStatus[constants.StepAdditionalWork] = true
+	return nil
+}
+
+// TriggerLifecycleCallbacks.cks runs lifecycle callbacks d.fore cleaning.
+func (d *DeployOnly) TriggerLifecycleCallbacks(config schemas.Config) error {
+	if !d.StepStatus[constants.StepAdditionalWork] {
+		return nil
+	}
+	return d.Deployer.TriggerLifecycleCallbacks(config)
+}
+
+//CleanPreviousVersion cleans previous version of autoscaling group
+func (d *DeployOnly) CleanPreviousVersion(config schemas.Config) error {
+	if !d.StepStatus[constants.StepTriggerLifecycleCallback] {
+		return nil
+	}
+	d.Logger.Debug("Delete Mode is " + d.Mode)
+
+	skipped := false
+	if len(config.Region) > 0 {
+		if !CheckRegionExist(config.Region, d.Stack.Regions) {
+			skipped = true
+		}
+	}
+
+	if !skipped {
+		if err := d.Deployer.CleanPreviousAutoScalingGroup(config); err != nil {
+			return err
+		}
+	}
+	d.StepStatus[constants.StepCleanPreviousVersion] = true
+	return nil
+}
+
+// CleanChecking checks Termination status
+func (d *DeployOnly) CleanChecking(config schemas.Config) error {
+	if !d.StepStatus[constants.StepCleanPreviousVersion] {
+		return nil
+	}
+	done := false
+
+	for !done {
+		isTimeout, _ := tool.CheckTimeout(config.StartTimestamp, config.Timeout)
+		if isTimeout {
+			return fmt.Errorf("timeout has been exceeded : %.0f minutes", config.Timeout.Minutes())
+		}
+
+		isDone, err := d.Deployer.CleanChecking(config)
+		if err != nil {
+			return errors.New("error happened while health checking")
+		}
+
+		if isDone {
+			done = true
+		} else {
+			d.Logger.Info("All stacks are not ready to be terminated... Please waiting...")
+			time.Sleep(config.PollingInterval)
+		}
+	}
+
+	d.StepStatus[constants.StepCleanChecking] = true
+	return nil
+}
+
+// GatherMetrics gathers the whole metrics from deployer
+func (d *DeployOnly) GatherMetrics(config schemas.Config) error {
+	if config.DisableMetrics {
+		return nil
+	}
+
+	if len(config.Region) > 0 {
+		if !CheckRegionExist(config.Region, d.Stack.Regions) {
+			return nil
+		}
+	}
+
+	if err := d.Deployer.StartGatheringMetrics(config); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RunAPITest tries to run API Test
+func (d *DeployOnly) RunAPITest(config schemas.Config) error {
+	return d.Deployer.RunAPITest(config)
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -630,10 +630,10 @@ func (r Runner) Refresh() error {
 	refresher.SetTarget(group)
 
 	input := make(chan error)
+
 	go func(ch chan error) {
 		ch <- refresher.StartRefresh(r.Builder.Config.InstanceWarmup, r.Builder.Config.MinHealthyPercentage)
 	}(input)
-
 	time.Sleep(3 * time.Second)
 
 	if err := refresher.StatusCheck(r.Builder.Config.PollingInterval, r.Builder.Config.Timeout); err != nil {
@@ -682,6 +682,8 @@ func getDeployer(logger *Logger.Logger, stack schemas.Stack, awsConfig schemas.A
 		d = deployer.NewCanary(&h)
 	case constants.RollingUpdateDeployment:
 		d = deployer.NewRollingUpdate(&h)
+	case constants.DeployOnly:
+		d = deployer.NewDeployOnly(&h)
 	}
 
 	return d


### PR DESCRIPTION
**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
We add a new replacement type `DeployOnly`. This can be used when there is no health check process like bastion server, sample test service for local development, etc.

With `DeployOnly` type, goployer will skip healthcheck process. It will provision a new version of autoscaling and delete the previous versions right away. It still checks whether all instances are successfully terminated.

**Follow-up Work (remove if N/A)**
Add end to end test code for deployonly type

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage!
Integration tests are sometimes an appropriate substitute.
-->
