### PR TITLE
add spot override instace types option

### DIFF
--- a/cmd/goployer/cmd/flag.go
+++ b/cmd/goployer/cmd/flag.go
@@ -166,6 +166,13 @@ var FlagRegistry = map[string][]Flag{
 			FlagAddMethod: "StringVar",
 		},
 		{
+			Name:          "override-spot-types",
+			Usage:         "Spot Instance Type to override",
+			Value:         aws.String(constants.EmptyString),
+			DefValue:      constants.EmptyString,
+			FlagAddMethod: "StringVar",
+		},
+		{
 			Name:          "disable-metrics",
 			Usage:         "Disable gathering metrics.",
 			Value:         aws.Bool(false),
@@ -298,6 +305,13 @@ var FlagRegistry = map[string][]Flag{
 		{
 			Name:          "override-instance-type",
 			Usage:         "Instance Type to override",
+			Value:         aws.String(constants.EmptyString),
+			DefValue:      constants.EmptyString,
+			FlagAddMethod: "StringVar",
+		},
+		{
+			Name:          "override-spot-types",
+			Usage:         "Spot Instance Type to override",
 			Value:         aws.String(constants.EmptyString),
 			DefValue:      constants.EmptyString,
 			FlagAddMethod: "StringVar",

--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -1221,3 +1221,28 @@ func (e EC2Client) DescribeInstanceRefreshes(name, id *string) (*autoscaling.Ins
 
 	return targets[0], nil
 }
+
+func (e EC2Client) DescribeInstanceTypes(client Client) ([]string, error) {
+	var instanceTypeList []string
+	ec2svc := client.EC2Service.Client
+	params := &ec2.DescribeInstanceTypesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("processor-info.supported-architecture"),
+				Values: []*string{aws.String("arm64")},
+			},
+		},
+	}
+	result, err := ec2svc.DescribeInstanceTypes(params)
+	if err == nil {
+		for i := 0; i < len(result.InstanceTypes); i++ {
+			instanceType := strings.Split(*result.InstanceTypes[i].InstanceType, ".")[0]
+			if !tool.IsStringInArray(instanceType, instanceTypeList) {
+				instanceTypeList = append(instanceTypeList, instanceType)
+			}
+		}
+	} else {
+		return nil, errors.New("you cannot get instanceType from aws, please check your configuration")
+	}
+	return instanceTypeList, nil
+}

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -100,6 +100,15 @@ func TestCheckValidationConfig(t *testing.T) {
 		t.Errorf("validation failed: metric file")
 	}
 	b.Config.DisableMetrics = true
+	b.Config.OverrideSpotType = "t3.small,t2.large|m5.small"
+	if err := b.CheckValidation(); err == nil || err.Error() != "you must using delimiter '|'" {
+		t.Errorf("validation failed: OverrideSpotType")
+	}
+
+	b.Config.OverrideSpotType = "t3.small|c6g.medium|t2.large"
+	if err := b.CheckValidation(); err == nil || err.Error() != "you can only use same type of spot instance type(arm64 and intel_x86 type)" {
+		t.Errorf("validation failed: OverrideSpotInstanceType")
+	}
 }
 
 func TestCheckValidationScheduledAction(t *testing.T) {

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -101,7 +101,7 @@ func TestCheckValidationConfig(t *testing.T) {
 	}
 	b.Config.DisableMetrics = true
 	b.Config.OverrideSpotType = "t3.small,t2.large|m5.small"
-	if err := b.CheckValidation(); err == nil || err.Error() != "you must using delimiter '|'" {
+	if err := b.CheckValidation(); err == nil || err.Error() != "you must use '|' for delimiter" {
 		t.Errorf("validation failed: OverrideSpotType")
 	}
 

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -99,16 +99,6 @@ func TestCheckValidationConfig(t *testing.T) {
 	if err := b.CheckValidation(); err == nil || err.Error() != fmt.Sprintf("no %s file exists", constants.MetricYamlPath) {
 		t.Errorf("validation failed: metric file")
 	}
-	b.Config.DisableMetrics = true
-	b.Config.OverrideSpotType = "t3.small,t2.large|m5.small"
-	if err := b.CheckValidation(); err == nil || err.Error() != "you must use '|' for delimiter" {
-		t.Errorf("validation failed: OverrideSpotType")
-	}
-
-	b.Config.OverrideSpotType = "t3.small|c6g.medium|t2.large"
-	if err := b.CheckValidation(); err == nil || err.Error() != "you can only use same type of spot instance type(arm64 and intel_x86 type)" {
-		t.Errorf("validation failed: OverrideSpotInstanceType")
-	}
 }
 
 func TestCheckValidationScheduledAction(t *testing.T) {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -170,6 +170,8 @@ const (
 	CanaryDeployment        = "canary"
 	RollingUpdateDeployment = "rollingupdate"
 	DeployOnly              = "deployonly"
+
+	DelimiterRegex = "[,/|!@$%^&*_=`~]+"
 )
 
 var (

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -603,7 +603,7 @@ func (d *Deployer) Deploy(config schemas.Config, region schemas.RegionConfig) er
 		instanceType = config.OverrideInstanceType
 
 		if d.Stack.MixedInstancesPolicy.Enabled {
-			d.Logger.Warnf("--override-instance-type won't be applied because mixed_instances_policy is enabled")
+			d.Logger.Warnf("if you want override-instance-type in  mixed_instances_policy, you must use --override-spot-instance-type option")
 		}
 
 		d.Logger.Debugf("Instance type is overridden with %s", config.OverrideInstanceType)
@@ -672,6 +672,12 @@ func (d *Deployer) Deploy(config schemas.Config, region schemas.RegionConfig) er
 
 	if len(region.TerminationPolicies) > 0 {
 		terminationPolicies = eaws.StringSlice(region.TerminationPolicies)
+	}
+
+	if d.Stack.MixedInstancesPolicy.Enabled {
+		if len(config.OverrideSpotType) > 0 {
+			d.Stack.MixedInstancesPolicy.Override = strings.Split(config.OverrideSpotType, "|")
+		}
 	}
 
 	err = client.EC2Service.CreateAutoScalingGroup(

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -678,11 +678,11 @@ func (d *Deployer) Deploy(config schemas.Config, region schemas.RegionConfig) er
 			overRideSpotInstanceType := config.OverrideSpotType
 			instanceTypeList, instanceTypeErr := client.EC2Service.DescribeInstanceTypes(client)
 			if instanceTypeErr == nil {
-				vaildErr := checkSpotInstanceOption(overRideSpotInstanceType, instanceTypeList)
-				if vaildErr == nil {
+				validErr := checkSpotInstanceOption(overRideSpotInstanceType, instanceTypeList)
+				if validErr == nil {
 					d.Stack.MixedInstancesPolicy.Override = strings.Split(config.OverrideSpotType, "|")
 				} else {
-					return vaildErr
+					return validErr
 				}
 			} else {
 				return instanceTypeErr

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -82,14 +82,14 @@ func TestDeployer_DecideCapacity(t *testing.T) {
 }
 
 func TestDeployer_ValidateOption(t *testing.T) {
-	overRideSpotInstanceType := "c6g.medium|c6g.large"
+	overRideSpotInstanceType := "t2.small|t3.small"
 	client := aws.BootstrapServices("ap-northeast-2", "")
 	instanceTypeList, InstanceTypeErr := client.EC2Service.DescribeInstanceTypes(client)
 	if InstanceTypeErr != nil {
-		t.Errorf("Failed to Get Arm64 Instance Types : %s", overRideSpotInstanceType)
+		t.Errorf("Failed to Get Arm64 Instance Types : %s", InstanceTypeErr)
 	}
 	validErr := checkSpotInstanceOption(overRideSpotInstanceType, instanceTypeList)
 	if validErr != nil {
-		t.Errorf("Invalid Override Spot Types Option: %s", overRideSpotInstanceType)
+		t.Errorf("Invalid Override Spot Types Option: %s", validErr)
 	}
 }

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -19,7 +19,6 @@ package deployer
 import (
 	"testing"
 
-	"github.com/DevopsArtFactory/goployer/pkg/aws"
 	"github.com/DevopsArtFactory/goployer/pkg/constants"
 	"github.com/DevopsArtFactory/goployer/pkg/schemas"
 )
@@ -83,11 +82,7 @@ func TestDeployer_DecideCapacity(t *testing.T) {
 
 func TestDeployer_ValidateOption(t *testing.T) {
 	overRideSpotInstanceType := "t2.small|t3.small"
-	client := aws.BootstrapServices("ap-northeast-2", "")
-	instanceTypeList, InstanceTypeErr := client.EC2Service.DescribeInstanceTypes(client)
-	if InstanceTypeErr != nil {
-		t.Errorf("Failed to Get Arm64 Instance Types : %s", InstanceTypeErr)
-	}
+	instanceTypeList := []string{"c6g", "t4g", "m6g", "a1", "r6g"}
 	validErr := checkSpotInstanceOption(overRideSpotInstanceType, instanceTypeList)
 	if validErr != nil {
 		t.Errorf("Invalid Override Spot Types Option: %s", validErr)

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -19,6 +19,7 @@ package deployer
 import (
 	"testing"
 
+	"github.com/DevopsArtFactory/goployer/pkg/aws"
 	"github.com/DevopsArtFactory/goployer/pkg/constants"
 	"github.com/DevopsArtFactory/goployer/pkg/schemas"
 )
@@ -77,5 +78,18 @@ func TestDeployer_DecideCapacity(t *testing.T) {
 	forceManifestCapacity = true
 	if out, _ := deployer.DecideCapacity(forceManifestCapacity, completeCanary, constants.DefaultRegion, len(deployer.PrevAsgs[constants.DefaultRegion]), deployer.Stack.RollingUpdateInstanceCount); out != intended {
 		t.Error("Canary capacity setting error with forceManifestCapacity")
+	}
+}
+
+func TestDeployer_ValidateOption(t *testing.T) {
+	overRideSpotInstanceType := "c6g.medium|c6g.large"
+	client := aws.BootstrapServices("ap-northeast-2", "")
+	instanceTypeList, InstanceTypeErr := client.EC2Service.DescribeInstanceTypes(client)
+	if InstanceTypeErr != nil {
+		t.Errorf("Failed to Get Arm64 Instance Types : %s", overRideSpotInstanceType)
+	}
+	validErr := checkSpotInstanceOption(overRideSpotInstanceType, instanceTypeList)
+	if validErr != nil {
+		t.Errorf("Invalid Override Spot Types Option: %s", overRideSpotInstanceType)
 	}
 }

--- a/pkg/schemas/config.go
+++ b/pkg/schemas/config.go
@@ -30,6 +30,7 @@ type Config struct { // Do not add comments for this struct
 	ExtraTags              string `json:"extra_tags"`
 	AnsibleExtraVars       string `json:"ansible_extra_vars"`
 	OverrideInstanceType   string `json:"override_instance_type"`
+	OverrideSpotType       string `json:"override_spot_types"`
 	ReleaseNotes           string `json:"release_notes"`
 	ReleaseNotesBase64     string `json:"release_notes_base64"`
 	Application            string


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #136  <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Mixed instance policy have override instance type, but this option cannot override in runtime. 

So, in this PR i implement instance type in mixed instance policy override in runtime.

multiple type also accept. but, only use same instance types.(arm64 and x86_64 cannot use at the same time)

ex) --override-spot-types="t2.nano|t3.large"

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
User use this option, then dynamically change spot instance type in goployer!!

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage!
Integration tests are sometimes an appropriate substitute.
-->
