### PR TITLE
add vaildation comparing override spot instance types and AMI Image a…

### DIFF
--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -1225,9 +1225,9 @@ func (e EC2Client) DescribeInstanceRefreshes(name, id *string) (*autoscaling.Ins
 	return targets[0], nil
 }
 
-func (e EC2Client) DescribeInstanceTypes(client Client) ([]string, error) {
+//aws ec2 describe-instance-types --filters Name=processor-info.supported-architecture,Values=arm64 --query "InstanceTypes[*].InstanceType"
+func (e EC2Client) DescribeInstanceTypes() ([]string, error) {
 	var instanceTypeList []string
-	ec2svc := client.EC2Service.Client
 	params := &ec2.DescribeInstanceTypesInput{
 		Filters: []*ec2.Filter{
 			{
@@ -1236,7 +1236,7 @@ func (e EC2Client) DescribeInstanceTypes(client Client) ([]string, error) {
 			},
 		},
 	}
-	result, err := ec2svc.DescribeInstanceTypes(params)
+	result, err := e.Client.DescribeInstanceTypes(params)
 	if err == nil {
 		for i := 0; i < len(result.InstanceTypes); i++ {
 			instanceType := strings.Split(*result.InstanceTypes[i].InstanceType, ".")[0]
@@ -1248,4 +1248,24 @@ func (e EC2Client) DescribeInstanceTypes(client Client) ([]string, error) {
 		return nil, errors.New("you cannot get instanceType from aws, please check your configuration")
 	}
 	return instanceTypeList, nil
+}
+
+//$ aws ec2 describe-images --filters Name=image-id,Values=ami-01288945bd24ed49a --query "Images[*].Architecture"
+func (e EC2Client) DescribeAMIArchitecture(amiID string) (string, error) {
+	var amiArchitecture string
+	params := &ec2.DescribeImagesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("image-id"),
+				Values: []*string{aws.String(amiID)},
+			},
+		},
+	}
+	result, err := e.Client.DescribeImages(params)
+	if err == nil {
+		amiArchitecture = *result.Images[0].Architecture
+	} else {
+		return "", errors.New("you cannot get ami-architecture from aws, please check your configuration")
+	}
+	return amiArchitecture, nil
 }

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -83,7 +83,7 @@ func TestDeployer_DecideCapacity(t *testing.T) {
 func TestDeployer_ValidateOption(t *testing.T) {
 	overRideSpotInstanceType := "t2.small|t3.small"
 	instanceTypeList := []string{"c6g", "t4g", "m6g", "a1", "r6g"}
-	validErr := checkSpotInstanceOption(overRideSpotInstanceType, instanceTypeList)
+	validErr := checkSpotInstanceOption(overRideSpotInstanceType, instanceTypeList, "")
 	if validErr != nil {
 		t.Errorf("Invalid Override Spot Types Option: %s", validErr)
 	}


### PR DESCRIPTION
…rchitecture

<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #139 <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
In issue #136, add override spot instance type option. But this modification isn't covered all case.
For example, when AMI Architecture is x86_64 and spot instance type are arm64, this case doesn't occurred error.
So In this PR, check AMI Architecture and Override spot instance type option input by user.

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage!
Integration tests are sometimes an appropriate substitute.
-->
