### PR TITLE
feat: enhance EBS volume management capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,60 @@ You can see the detailed information in [manifest format](https://goployer.dev/d
 cd examples/manifests
 ```
 
+## EBS Volume Configuration
+
+Goployer supports advanced EBS volume management with the following features. You can find a complete example in [api-test-example.yaml](examples/manifests/api-test-example.yaml).
+
+### Basic Configuration
+```yaml
+block_devices:
+  - device_name: /dev/xvda
+    volume_size: 30
+    volume_type: gp3
+```
+
+### Delete on Termination
+Control whether EBS volumes should be deleted when the instance terminates:
+```yaml
+block_devices:
+  - device_name: /dev/xvda
+    volume_size: 30
+    volume_type: gp3
+    delete_on_termination: false  # optional, defaults to false
+```
+
+### Snapshot Support
+Create volumes from existing snapshots:
+```yaml
+block_devices:
+  - device_name: /dev/sdf
+    snapshot_id: snap-1234567890abcdef0  # optional, for volume creation from snapshot
+    volume_size: 100
+    volume_type: gp3
+    delete_on_termination: true
+```
+
+### Encrypted Volumes
+Create encrypted volumes with KMS:
+```yaml
+block_devices:
+  - device_name: /dev/sdg
+    volume_size: 50
+    volume_type: gp3
+    encrypted: true
+    kms_alias: alias/my-kms-key
+    delete_on_termination: false
+```
+
+### Configuration Options
+- `device_name`: The device name to expose to the instance
+- `volume_size`: Size of the volume in GiB
+- `volume_type`: Type of EBS volume (gp2, gp3, io1, io2, st1, sc1)
+- `delete_on_termination`: Whether to delete the volume on instance termination (default: false)
+- `snapshot_id`: ID of the snapshot to create the volume from (optional)
+- `encrypted`: Whether to encrypt the volume (default: false)
+- `kms_alias`: KMS key alias for encryption (required if encrypted is true)
+
+For a complete example showing how to use these features together, see [api-test-example.yaml](examples/manifests/api-test-example.yaml).
+
 

--- a/examples/manifests/api-test-example.yaml
+++ b/examples/manifests/api-test-example.yaml
@@ -64,9 +64,16 @@ stacks:
       - device_name: /dev/xvda
         volume_size: 10
         volume_type: "gp2"
+        delete_on_termination: false  # root volume will be preserved
       - device_name: /dev/xvdb
         volume_type: "st1"
         volume_size: 500
+        delete_on_termination: true  # data volume will be deleted
+      - device_name: /dev/xvdc
+        snapshot_id: snap-1234567890abcdef0  # volume created from snapshot
+        volume_size: 100
+        volume_type: "gp3"
+        delete_on_termination: false  # preserve snapshot-based volume
     capacity:
       min: 1
       max: 2

--- a/pkg/aws/ec2_test.go
+++ b/pkg/aws/ec2_test.go
@@ -1,0 +1,173 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DevopsArtFactory/goployer/pkg/schemas"
+)
+
+func TestMakeLaunchTemplateBlockDeviceMappings(t *testing.T) {
+	tests := []struct {
+		name     string
+		blocks   []schemas.BlockDevice
+		expected []*ec2.LaunchTemplateBlockDeviceMappingRequest
+	}{
+		{
+			name: "Basic EBS volume",
+			blocks: []schemas.BlockDevice{
+				{
+					DeviceName: "/dev/xvda",
+					VolumeSize: 30,
+					VolumeType: "gp2",
+				},
+			},
+			expected: []*ec2.LaunchTemplateBlockDeviceMappingRequest{
+				{
+					DeviceName: stringPtr("/dev/xvda"),
+					Ebs: &ec2.LaunchTemplateEbsBlockDeviceRequest{
+						VolumeSize:          int64Ptr(30),
+						VolumeType:          stringPtr("gp2"),
+						DeleteOnTermination: boolPtr(false),
+					},
+				},
+			},
+		},
+		{
+			name: "EBS volume with DeleteOnTermination",
+			blocks: []schemas.BlockDevice{
+				{
+					DeviceName:          "/dev/xvda",
+					VolumeSize:          30,
+					VolumeType:          "gp2",
+					DeleteOnTermination: true,
+				},
+			},
+			expected: []*ec2.LaunchTemplateBlockDeviceMappingRequest{
+				{
+					DeviceName: stringPtr("/dev/xvda"),
+					Ebs: &ec2.LaunchTemplateEbsBlockDeviceRequest{
+						VolumeSize:          int64Ptr(30),
+						VolumeType:          stringPtr("gp2"),
+						DeleteOnTermination: boolPtr(true),
+					},
+				},
+			},
+		},
+		{
+			name: "EBS volume with valid snapshot",
+			blocks: []schemas.BlockDevice{
+				{
+					DeviceName: "/dev/xvda",
+					VolumeSize: 30,
+					VolumeType: "gp2",
+					SnapshotID: "snap-12345678",
+				},
+			},
+			expected: []*ec2.LaunchTemplateBlockDeviceMappingRequest{
+				{
+					DeviceName: stringPtr("/dev/xvda"),
+					Ebs: &ec2.LaunchTemplateEbsBlockDeviceRequest{
+						VolumeSize:          int64Ptr(30),
+						VolumeType:          stringPtr("gp2"),
+						SnapshotId:          stringPtr("snap-12345678"),
+						DeleteOnTermination: boolPtr(false),
+					},
+				},
+			},
+		},
+		{
+			name: "EBS volume with invalid snapshot",
+			blocks: []schemas.BlockDevice{
+				{
+					DeviceName: "/dev/xvda",
+					VolumeSize: 30,
+					VolumeType: "gp2",
+					SnapshotID: "snap-invalid",
+				},
+			},
+			expected: []*ec2.LaunchTemplateBlockDeviceMappingRequest{},
+		},
+		{
+			name: "EBS volume with long snapshot",
+			blocks: []schemas.BlockDevice{
+				{
+					DeviceName: "/dev/xvda",
+					VolumeSize: 30,
+					VolumeType: "gp2",
+					SnapshotID: "snap-1234567890abcdef0",
+				},
+			},
+			expected: []*ec2.LaunchTemplateBlockDeviceMappingRequest{
+				{
+					DeviceName: stringPtr("/dev/xvda"),
+					Ebs: &ec2.LaunchTemplateEbsBlockDeviceRequest{
+						VolumeSize:          int64Ptr(30),
+						VolumeType:          stringPtr("gp2"),
+						SnapshotId:          stringPtr("snap-1234567890abcdef0"),
+						DeleteOnTermination: boolPtr(false),
+					},
+				},
+			},
+		},
+		{
+			name: "IOPS volume",
+			blocks: []schemas.BlockDevice{
+				{
+					DeviceName: "/dev/xvda",
+					VolumeSize: 30,
+					VolumeType: "io1",
+					Iops:       3000,
+				},
+			},
+			expected: []*ec2.LaunchTemplateBlockDeviceMappingRequest{
+				{
+					DeviceName: stringPtr("/dev/xvda"),
+					Ebs: &ec2.LaunchTemplateEbsBlockDeviceRequest{
+						VolumeSize:          int64Ptr(30),
+						VolumeType:          stringPtr("io1"),
+						Iops:                int64Ptr(3000),
+						DeleteOnTermination: boolPtr(false),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := EC2Client{}
+			result := client.MakeLaunchTemplateBlockDeviceMappings(tt.blocks)
+
+			assert.Equal(t, len(tt.expected), len(result))
+			for i, expected := range tt.expected {
+				assert.Equal(t, *expected.DeviceName, *result[i].DeviceName)
+				assert.Equal(t, *expected.Ebs.VolumeSize, *result[i].Ebs.VolumeSize)
+				assert.Equal(t, *expected.Ebs.VolumeType, *result[i].Ebs.VolumeType)
+				assert.Equal(t, *expected.Ebs.DeleteOnTermination, *result[i].Ebs.DeleteOnTermination)
+
+				if expected.Ebs.SnapshotId != nil {
+					assert.Equal(t, *expected.Ebs.SnapshotId, *result[i].Ebs.SnapshotId)
+				}
+				if expected.Ebs.Iops != nil {
+					assert.Equal(t, *expected.Ebs.Iops, *result[i].Ebs.Iops)
+				}
+			}
+		})
+	}
+}
+
+// Helper functions for creating pointers
+func stringPtr(s string) *string {
+	return &s
+}
+
+func int64Ptr(i int64) *int64 {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/pkg/schemas/config.go
+++ b/pkg/schemas/config.go
@@ -236,6 +236,7 @@ type BlockDevice struct {
 	// Name of block device
 	DeviceName string `yaml:"device_name"`
 
+	SnapshotID string `yaml:"snapshot_id"`
 	// Size of volume
 	VolumeSize int64 `yaml:"volume_size"`
 
@@ -250,6 +251,9 @@ type BlockDevice struct {
 
 	// KMS key
 	KmsAlias string `yaml:"kmsAlias"`
+
+	// Whether to delete the volume on instance termination
+	DeleteOnTermination bool `yaml:"delete_on_termination"`
 }
 
 // Lifecycle Callback configuration


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #154 <!-- tracking issues that this PR will close -->
**Related**: #154 <!-- EBS Volume Management Enhancement -->
**Merge before/after**: None

**Description**
This PR implements the EBS volume management enhancement requested in #154, adding two key features:

1. DeleteOnTermination Support
   - Added `DeleteOnTermination` field to `BlockDevice` struct
   - Implemented in both `MakeLaunchTemplateBlockDeviceMappings` and `MakeBlockDevices`
   - Default value is `false` (volumes are preserved on instance termination)
   - Optional configuration in manifest files

2. Snapshot Support
   - Added support for creating EBS volumes from existing snapshots
   - Implemented in both launch template and launch configuration
   - Allows for data persistence and volume restoration

**User facing changes**
Before:
```yaml
block_devices:
  - device_name: /dev/xvda
    volume_size: 30
    volume_type: gp3
```

After:
```yaml
block_devices:
  - device_name: /dev/xvda
    volume_size: 30
    volume_type: gp3
    delete_on_termination: false  # optional, defaults to false
    snapshot_id: snap-1234567890  # optional, for volume creation from snapshot
```

**Follow-up Work**
- Add validation for snapshot existence
- Add documentation examples for common EBS volume management scenarios
- Consider adding support for volume tags during creation
- Add integration tests for snapshot-based volume creation

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage!
Integration tests are sometimes an appropriate substitute.
-->