### PR TITLE
disable docker build when release-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,12 +115,12 @@ build: format cross $(BUILD_DIR)/VERSION
 
 .PHONY: release-build
 release-build: format cross
-	docker build \
-		-f deploy/goployer/Dockerfile \
-		--target release \
-		-t gcr.io/$(GCP_PROJECT)/goployer:edge \
-		-t gcr.io/$(GCP_PROJECT)/goployer:$(COMMIT) \
-		.
+#	docker build \
+#		-f deploy/Dockerfile \
+#		--target release \
+#		-t gcr.io/$(GCP_PROJECT)/goployer:edge \
+#		-t gcr.io/$(GCP_PROJECT)/goployer:$(COMMIT) \
+#		.
 	aws s3 cp $(BUILD_DIR)/$(PROJECT)-* $(S3_RELEASE_PATH)/
 	aws s3 cp -r $(S3_RELEASE_PATH)/* $(S3_RELEASE_LATEST)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #nnn <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_
when execute release-build, disable docker build.
Because docker image not using current.

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage!
Integration tests are sometimes an appropriate substitute.
-->
