### PR TITLE
feat:modify remove previous asg after goployer timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ S3_RELEASE_PATH ?= s3://$(RELEASE_BUCKET)/releases/$(VERSION)
 S3_RELEASE_LATEST ?= s3://$(RELEASE_BUCKET)/releases/latest
 S3_BLEEDING_EDGE_LATEST ?= s3://$(RELEASE_BUCKET)/edge/latest
 S3_EXPERIMENTAL_LATEST ?= s3://$(RELEASE_BUCKET)/experimental/latest
-VERSION = 2.1.3
+VERSION = 2.1.4
 
 GCP_ONLY ?= false
 GCP_PROJECT ?= goployer

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ S3_RELEASE_PATH ?= s3://$(RELEASE_BUCKET)/releases/$(VERSION)
 S3_RELEASE_LATEST ?= s3://$(RELEASE_BUCKET)/releases/latest
 S3_BLEEDING_EDGE_LATEST ?= s3://$(RELEASE_BUCKET)/edge/latest
 S3_EXPERIMENTAL_LATEST ?= s3://$(RELEASE_BUCKET)/experimental/latest
-VERSION = 2.1.1
+VERSION = 2.1.2
 
 GCP_ONLY ?= false
 GCP_PROJECT ?= goployer

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -88,3 +88,28 @@ func TestDeployer_ValidateOption(t *testing.T) {
 		t.Errorf("Invalid Override Spot Types Option: %s", validErr)
 	}
 }
+
+func TestDeployer_HealthCheckingStatus(t *testing.T) {
+	deployer := Deployer{
+		HealthCheckStatus: make(map[string]bool),
+		StepStatus:        map[int64]bool{constants.StepDeploy: true},
+		Stack: schemas.Stack{
+			Regions: []schemas.RegionConfig{
+				{Region: "ap-northeast-2"},
+			},
+		},
+	}
+
+	// Initially, health check status should be false or not set
+	if status, exists := deployer.HealthCheckStatus["ap-northeast-2"]; exists && status {
+		t.Error("HealthCheckStatus should not be true initially")
+	}
+
+	// Simulate successful health check by setting the status
+	deployer.HealthCheckStatus["ap-northeast-2"] = true
+
+	// Verify that the status is now true
+	if !deployer.HealthCheckStatus["ap-northeast-2"] {
+		t.Error("HealthCheckStatus should be true after successful health check")
+	}
+}

--- a/pkg/sumdb/sum.golang.org/latest
+++ b/pkg/sumdb/sum.golang.org/latest
@@ -1,0 +1,5 @@
+go.sum database tree
+43279701
+Um2aeKGAneeDXP1z1W4ltGD2tkI7jyD5f7tdq71kyuY=
+
+— sum.golang.org Az3grgUju0c9GRK4rchalgvdwabWuqx1vJc2cdPRk58Seb1AqAEpfwzNtdDPJzKRKzokjOdVXUxLdKQ5VmioyPvKHQo=


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #nnn <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Goployer is Default timeout 3600s(1h). When Deploy EC2 cannot healtch before timeout, then goployer remove previous AutoSacligGroup. 

So, Service return 503, and unavailble status. 

In this PR, stroe healtcheck flag and check flag for remove previous auto scaling group
**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage!
Integration tests are sometimes an appropriate substitute.
-->
