### PR TITLE
add metadata options to launch template creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ S3_RELEASE_PATH ?= s3://$(RELEASE_BUCKET)/releases/$(VERSION)
 S3_RELEASE_LATEST ?= s3://$(RELEASE_BUCKET)/releases/latest
 S3_BLEEDING_EDGE_LATEST ?= s3://$(RELEASE_BUCKET)/edge/latest
 S3_EXPERIMENTAL_LATEST ?= s3://$(RELEASE_BUCKET)/experimental/latest
-VERSION = 2.1.2
+VERSION = 2.1.3
 
 GCP_ONLY ?= false
 GCP_PROJECT ?= goployer

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -632,6 +632,7 @@ func (d *Deployer) Deploy(config schemas.Config, region schemas.RegionConfig) er
 		region.PrimaryENI,
 		region.SecondaryENIs,
 		launchTemplateTags,
+		region.HttpPutResponseHopLimit,
 	)
 
 	if err != nil {

--- a/pkg/schemas/config.go
+++ b/pkg/schemas/config.go
@@ -364,6 +364,9 @@ type RegionConfig struct {
 
 	// Detailed Monitoring Enabled
 	DetailedMonitoringEnabled bool `yaml:"detailed_monitoring_enabled"`
+
+	// HTTP PUT response hop limit for IMDSv2 (default: 1)
+	HttpPutResponseHopLimit int64 `yaml:"http_put_response_hop_limit,omitempty"`
 }
 
 // ENI Configuration


### PR DESCRIPTION
**Description**
This PR enforces IMDSv2 (Instance Metadata Service Version 2) for all EC2 instances deployed via goployer by adding metadata options to the launch template configuration.

**Changes:**
- Added `MetadataOptions` field to `CreateNewLaunchTemplate` function in `pkg/aws/ec2.go`
- Set `HttpTokens: "required"` to enforce IMDSv2 token-based authentication
- Set `HttpPutResponseHopLimit` with configurable default of 1 for security hardening
- Set `HttpEndpoint: "enabled"` to keep metadata service accessible
- Added `HttpPutResponseHopLimit` field to `RegionConfig` schema for user configuration

**Security Benefits:**
- Prevents SSRF (Server-Side Request Forgery) attacks targeting IMDS
- Requires session tokens for metadata access, improving security posture
- Aligns with AWS security best practices and compliance requirements

**User facing changes**
**Before:**
- EC2 instances deployed with IMDSv1 enabled by default
- Metadata accessible via simple HTTP requests without authentication

**After:**
- All newly deployed EC2 instances automatically use IMDSv2
- Metadata access requires token-based authentication
- Existing manifest files require no changes
- Optional configuration available:
```yaml
regions:
  - region: us-east-1
    http_put_response_hop_limit: 2  # Optional, defaults to 1
```



**Testing:**

- Added comprehensive unit tests for hop limit logic validation

- Added security configuration tests to ensure IMDSv2 enforcement

```
=== RUN   TestIMDSv2HopLimitLogic
=== RUN   TestIMDSv2HopLimitLogic/Zero_defaults_to_1
=== RUN   TestIMDSv2HopLimitLogic/Negative_defaults_to_1
=== RUN   TestIMDSv2HopLimitLogic/Positive_preserved
=== RUN   TestIMDSv2HopLimitLogic/Max_value_preserved
--- PASS: TestIMDSv2HopLimitLogic (0.00s)
    --- PASS: TestIMDSv2HopLimitLogic/Zero_defaults_to_1 (0.00s)
    --- PASS: TestIMDSv2HopLimitLogic/Negative_defaults_to_1 (0.00s)
    --- PASS: TestIMDSv2HopLimitLogic/Positive_preserved (0.00s)
    --- PASS: TestIMDSv2HopLimitLogic/Max_value_preserved (0.00s)
=== RUN   TestIMDSv2SecuritySettings
--- PASS: TestIMDSv2SecuritySettings (0.00s)
=== RUN   TestRegionConfigHopLimit
=== RUN   TestRegionConfigHopLimit/Default_when_not_set
=== RUN   TestRegionConfigHopLimit/Custom_value_preserved
--- PASS: TestRegionConfigHopLimit (0.00s)
    --- PASS: TestRegionConfigHopLimit/Default_when_not_set (0.00s)
    --- PASS: TestRegionConfigHopLimit/Custom_value_preserved (0.00s)
PASS
 ```


