### PR TITLE
Support weighted target group canary deployments

### DIFF
--- a/docs/content/en/docs/Concepts/canary.md
+++ b/docs/content/en/docs/Concepts/canary.md
@@ -18,6 +18,18 @@ This mode reuses the existing load balancer listener default action instead of c
 
 This implementation supports listener default actions. Listener rule based canary routing is not supported yet.
 
+## Health check rollback
+
+If the canary Auto Scaling group fails health checks or the health check step times out after the deploy step, Goployer automatically rolls the canary back before returning the error:
+
+1. Restore the listener default action to the original target group.
+2. Detach and delete the canary target group.
+3. Scale the failed canary Auto Scaling group to `0`.
+4. Wait until the failed canary Auto Scaling group has no instances.
+5. Delete the failed canary Auto Scaling group and its launch template.
+
+When rollback succeeds, Goployer clears the canary deploy step status so later finish/cleanup phases do not promote the failed canary.
+
 ## Manifest
 
 ```yaml
@@ -48,6 +60,7 @@ regions:
 - NLB weight changes apply to new flows, not existing connections.
 - Goployer treats `canary.weight` as a percentage, so valid values are `0` through `90`.
 - `canary.bake_time` only waits. CloudWatch alarm or API test based promotion gates should be added separately.
+- Automatic rollback is tied to Goployer health check failures. It does not monitor CloudWatch alarms after the deploy command exits.
 
 ## Commands
 

--- a/docs/content/en/docs/Concepts/canary.md
+++ b/docs/content/en/docs/Concepts/canary.md
@@ -1,0 +1,64 @@
+---
+title: "Weighted Canary Deployment"
+linkTitle: "Weighted Canary"
+weight: 45
+description: >
+  Shift a small percentage of load balancer traffic to a canary Auto Scaling group.
+---
+
+Goployer can run canary deployments with ALB/NLB weighted target groups.
+This mode reuses the existing load balancer listener default action instead of creating a separate canary load balancer.
+
+## How it works
+
+1. Goployer copies the configured `healthcheck_target_group` into a new canary target group named like `hello-dev-canary-v001`.
+2. Goployer creates a new Auto Scaling group and attaches it only to the canary target group.
+3. After the canary Auto Scaling group passes health checks, Goployer changes the existing listener default action to split traffic between the original target group and the canary target group.
+4. `--complete-canary` attaches the canary Auto Scaling group back to the original target group, restores the listener to the original target group, and removes canary-only resources.
+
+This implementation supports listener default actions. Listener rule based canary routing is not supported yet.
+
+## Manifest
+
+```yaml
+replacement_type: Canary
+regions:
+  - region: ap-northeast-2
+    healthcheck_target_group: hello-artdapne2-ext
+    target_groups:
+      - hello-artdapne2-ext
+    canary:
+      load_balancer: hello-artdapne2-ext
+      listener_port: 443
+      listener_protocol: HTTPS
+      weight: 10
+      bake_time: 10m
+```
+
+`canary.load_balancer` and `canary.listener_port` identify the listener whose default action currently forwards to `healthcheck_target_group`.
+`canary.listener_protocol` is optional and useful when you want to make the listener match explicit. You can still set `canary.listener_arn` directly for backward compatibility.
+`canary.weight` is the percentage of traffic sent to the canary target group. If it is omitted or set to `0`, Goployer uses `10`.
+`canary.bake_time` keeps the canary traffic active before the deploy command exits. If omitted, Goployer does not wait.
+
+## Constraints
+
+- ALB and NLB listener default actions are supported.
+- NLB weighted listeners cannot mix TCP, TLS, and UDP target groups on the same listener.
+- Weighted target groups must use the same IP address type.
+- NLB weight changes apply to new flows, not existing connections.
+- Goployer treats `canary.weight` as a percentage, so valid values are `0` through `99`.
+- `canary.bake_time` only waits. CloudWatch alarm or API test based promotion gates should be added separately.
+
+## Commands
+
+Start canary deployment:
+
+```bash
+goployer deploy --manifest examples/manifests/canary-example.yaml --stack artd
+```
+
+Complete canary deployment:
+
+```bash
+goployer deploy --manifest examples/manifests/canary-example.yaml --stack artd --complete-canary
+```

--- a/docs/content/en/docs/Concepts/canary.md
+++ b/docs/content/en/docs/Concepts/canary.md
@@ -46,7 +46,7 @@ regions:
 - NLB weighted listeners cannot mix TCP, TLS, and UDP target groups on the same listener.
 - Weighted target groups must use the same IP address type.
 - NLB weight changes apply to new flows, not existing connections.
-- Goployer treats `canary.weight` as a percentage, so valid values are `0` through `99`.
+- Goployer treats `canary.weight` as a percentage, so valid values are `0` through `90`.
 - `canary.bake_time` only waits. CloudWatch alarm or API test based promotion gates should be added separately.
 
 ## Commands

--- a/docs/content/en/schemas/schema.json
+++ b/docs/content/en/schemas/schema.json
@@ -119,17 +119,45 @@
     },
     "BlockDevice": {
       "properties": {
+        "delete_on_termination": {
+          "type": "boolean",
+          "description": "Whether to delete the volume on instance termination",
+          "x-intellij-html-description": "Whether to delete the volume on instance termination",
+          "default": "false"
+        },
         "device_name": {
           "type": "string",
           "description": "Name of block device",
           "x-intellij-html-description": "Name of block device",
           "default": "\"\""
         },
+        "encrypted": {
+          "type": "boolean",
+          "description": "Enable Encrypted",
+          "x-intellij-html-description": "Enable Encrypted",
+          "default": "false"
+        },
         "iops": {
           "type": "integer",
           "description": "IOPS for io1, io2 volume",
           "x-intellij-html-description": "IOPS for io1, io2 volume",
           "default": "0"
+        },
+        "kmsAlias": {
+          "type": "string",
+          "description": "KMS key alias",
+          "x-intellij-html-description": "KMS key alias",
+          "default": "\"\""
+        },
+        "kmsKeyId": {
+          "type": "string",
+          "description": "KMS key ID (ARN or key ID)",
+          "x-intellij-html-description": "KMS key ID (ARN or key ID)",
+          "default": "\"\""
+        },
+        "snapshot_id": {
+          "type": "string",
+          "default": "\"\""
         },
         "volume_size": {
           "type": "integer",
@@ -147,12 +175,65 @@
       "additionalProperties": false,
       "preferredOrder": [
         "device_name",
+        "snapshot_id",
         "volume_size",
         "volume_type",
-        "iops"
+        "iops",
+        "encrypted",
+        "kmsAlias",
+        "kmsKeyId",
+        "delete_on_termination"
       ],
       "description": "EBS Block device configuration",
       "x-intellij-html-description": "EBS Block device configuration"
+    },
+    "CanaryConfig": {
+      "properties": {
+        "bake_time": {
+          "description": "Time to keep canary traffic before finishing the canary deployment step",
+          "x-intellij-html-description": "Time to keep canary traffic before finishing the canary deployment step"
+        },
+        "listener_arn": {
+          "type": "string",
+          "description": "Existing listener ARN whose default action forwards to the production target group",
+          "x-intellij-html-description": "Existing listener ARN whose default action forwards to the production target group",
+          "default": "\"\""
+        },
+        "listener_port": {
+          "type": "integer",
+          "description": "Existing listener port whose default action forwards to the production target group",
+          "x-intellij-html-description": "Existing listener port whose default action forwards to the production target group"
+        },
+        "listener_protocol": {
+          "type": "string",
+          "description": "Existing listener protocol. Optional when listener_port is unique",
+          "x-intellij-html-description": "Existing listener protocol. Optional when listener_port is unique",
+          "default": "\"\""
+        },
+        "load_balancer": {
+          "type": "string",
+          "description": "Existing load balancer name that owns the canary listener",
+          "x-intellij-html-description": "Existing load balancer name that owns the canary listener",
+          "default": "\"\""
+        },
+        "weight": {
+          "type": "integer",
+          "description": "Percentage of traffic to send to the canary target group.",
+          "x-intellij-html-description": "Percentage of traffic to send to the canary target group.",
+          "default": "10"
+        }
+      },
+      "additionalProperties": false,
+      "preferredOrder": [
+        "listener_arn",
+        "load_balancer",
+        "listener_port",
+        "listener_protocol",
+        "bake_time",
+        "weight"
+      ],
+      "description": "configures weighted target group canary deployment",
+      "x-intellij-html-description": "configures weighted target group canary deployment"
     },
     "Capacity": {
       "properties": {
@@ -183,6 +264,54 @@
       ],
       "description": "Instance capacity of autoscaling group",
       "x-intellij-html-description": "Instance capacity of autoscaling group"
+    },
+    "ENIConfig": {
+      "properties": {
+        "delete_on_termination": {
+          "type": "boolean",
+          "description": "Delete on termination flag",
+          "x-intellij-html-description": "Delete on termination flag",
+          "default": "false"
+        },
+        "device_index": {
+          "type": "integer",
+          "description": "Device index for ENI",
+          "x-intellij-html-description": "Device index for ENI",
+          "default": "0"
+        },
+        "private_ip_address": {
+          "type": "string",
+          "description": "Private IP address for ENI",
+          "x-intellij-html-description": "Private IP address for ENI",
+          "default": "\"\""
+        },
+        "security_groups": {
+          "items": {
+            "type": "string",
+            "default": "\"\""
+          },
+          "type": "array",
+          "description": "Security groups for ENI",
+          "x-intellij-html-description": "Security groups for ENI",
+          "default": "[]"
+        },
+        "subnet_id": {
+          "type": "string",
+          "description": "Subnet ID for ENI",
+          "x-intellij-html-description": "Subnet ID for ENI",
+          "default": "\"\""
+        }
+      },
+      "additionalProperties": false,
+      "preferredOrder": [
+        "device_index",
+        "subnet_id",
+        "security_groups",
+        "private_ip_address",
+        "delete_on_termination"
+      ],
+      "description": "ENI Configuration",
+      "x-intellij-html-description": "ENI Configuration"
     },
     "InstanceMarketOptions": {
       "properties": {
@@ -384,6 +513,11 @@
           "x-intellij-html-description": "Availability zones for autoscaling group",
           "default": "[]"
         },
+        "canary": {
+          "$ref": "#/definitions/CanaryConfig",
+          "description": "deployment configuration",
+          "x-intellij-html-description": "deployment configuration"
+        },
         "detailed_monitoring_enabled": {
           "type": "boolean",
           "description": "Detailed Monitoring Enabled",
@@ -402,6 +536,12 @@
           "x-intellij-html-description": "Target group name for healthcheck",
           "default": "\"\""
         },
+        "http_put_response_hop_limit": {
+          "type": "integer",
+          "description": "HTTP PUT response hop limit for IMDSv2 (default: 1)",
+          "x-intellij-html-description": "HTTP PUT response hop limit for IMDSv2 (default: 1)",
+          "default": "0"
+        },
         "instance_type": {
           "type": "string",
           "description": "Type of EC2 instance",
@@ -417,6 +557,11 @@
           "description": "List of  load balancers",
           "x-intellij-html-description": "List of  load balancers",
           "default": "[]"
+        },
+        "primary_eni": {
+          "$ref": "#/definitions/ENIConfig",
+          "description": "Primary ENI configuration",
+          "x-intellij-html-description": "Primary ENI configuration"
         },
         "region": {
           "type": "string",
@@ -434,6 +579,14 @@
           "x-intellij-html-description": "List of scheduled actions",
           "default": "[]"
         },
+        "secondary_enis": {
+          "items": {
+            "$ref": "#/definitions/ENIConfig"
+          },
+          "type": "array",
+          "description": "Secondary ENI configurations",
+          "x-intellij-html-description": "Secondary ENI configurations"
+        },
         "security_groups": {
           "items": {
             "type": "string",
@@ -449,6 +602,16 @@
           "description": "Key name of SSH access",
           "x-intellij-html-description": "Key name of SSH access",
           "default": "\"\""
+        },
+        "subnet_ids": {
+          "items": {
+            "type": "string",
+            "default": "\"\""
+          },
+          "type": "array",
+          "description": "Ids of subnets",
+          "x-intellij-html-description": "Ids of subnets",
+          "default": "[]"
         },
         "target_groups": {
           "items": {
@@ -490,16 +653,21 @@
         "ssh_key",
         "ami_id",
         "vpc",
+        "subnet_ids",
+        "primary_eni",
+        "secondary_enis",
         "healthcheck_load_balancer",
         "healthcheck_target_group",
         "security_groups",
         "scheduled_actions",
         "target_groups",
+        "canary",
         "loadbalancers",
         "availability_zones",
         "termination_policies",
         "use_public_subnets",
-        "detailed_monitoring_enabled"
+        "detailed_monitoring_enabled",
+        "http_put_response_hop_limit"
       ],
       "description": "Region configuration",
       "x-intellij-html-description": "Region configuration"

--- a/docs/content/en/schemas/schema.json
+++ b/docs/content/en/schemas/schema.json
@@ -220,7 +220,7 @@
           "type": "integer",
           "description": "Percentage of traffic to send to the canary target group.",
           "x-intellij-html-description": "Percentage of traffic to send to the canary target group.",
-          "default": "10"
+          "default": "10`; maximum is `90"
         }
       },
       "additionalProperties": false,

--- a/docs/content/ko/docs/Concepts/canary.md
+++ b/docs/content/ko/docs/Concepts/canary.md
@@ -46,7 +46,7 @@ regions:
 - NLB는 같은 listener 안에서 TCP/TLS/UDP target group을 섞을 수 없습니다.
 - weighted target groups는 같은 IP address type의 target group끼리 사용해야 합니다.
 - NLB weight 변경은 기존 연결이 아니라 새 flow부터 반영됩니다.
-- Goployer의 `canary.weight`는 percentage 값이라 `0`부터 `99`까지만 허용합니다.
+- Goployer의 `canary.weight`는 percentage 값이라 `0`부터 `90`까지만 허용합니다.
 - `canary.bake_time`은 시간 대기만 수행합니다. CloudWatch alarm이나 API test 기반 자동 승격 판단은 별도 승격 조건으로 구성해야 합니다.
 
 ## Commands

--- a/docs/content/ko/docs/Concepts/canary.md
+++ b/docs/content/ko/docs/Concepts/canary.md
@@ -1,0 +1,64 @@
+---
+title: "Weighted Canary Deployment"
+linkTitle: "Weighted Canary"
+weight: 45
+description: >
+  Load Balancer weighted target groups를 이용해 일부 트래픽만 canary Auto Scaling group으로 보냅니다.
+---
+
+Goployer의 canary 배포는 ALB/NLB weighted target groups를 사용합니다.
+별도의 canary load balancer를 만들지 않고, 기존 load balancer listener의 default action을 수정합니다.
+
+## 동작 방식
+
+1. `healthcheck_target_group`으로 지정된 기존 target group을 복사해 `hello-dev-canary-v001` 같은 canary target group을 만듭니다.
+2. 새 Auto Scaling group을 만들고 canary target group에만 붙입니다.
+3. canary Auto Scaling group이 health check를 통과하면 기존 listener default action을 original target group과 canary target group의 weighted forward로 변경합니다.
+4. `--complete-canary`를 실행하면 canary Auto Scaling group을 original target group에 붙이고, listener를 original target group으로 복구한 뒤 canary 전용 리소스를 정리합니다.
+
+현재 구현은 listener default action만 지원합니다. host/path 기반 listener rule canary는 아직 지원하지 않습니다.
+
+## Manifest
+
+```yaml
+replacement_type: Canary
+regions:
+  - region: ap-northeast-2
+    healthcheck_target_group: hello-artdapne2-ext
+    target_groups:
+      - hello-artdapne2-ext
+    canary:
+      load_balancer: hello-artdapne2-ext
+      listener_port: 443
+      listener_protocol: HTTPS
+      weight: 10
+      bake_time: 10m
+```
+
+`canary.load_balancer`와 `canary.listener_port`는 현재 `healthcheck_target_group`으로 forward하고 있는 listener를 찾는 데 사용합니다.
+`canary.listener_protocol`은 같은 port/protocol을 명확히 표시하고 싶을 때 지정합니다. 기존 방식처럼 `canary.listener_arn`을 직접 지정할 수도 있습니다.
+`canary.weight`는 canary target group으로 보낼 트래픽 비율입니다. 생략하거나 `0`이면 기본값 `10`을 사용합니다.
+`canary.bake_time`은 canary traffic을 유지하며 배포 명령이 기다릴 시간입니다. 생략하면 기다리지 않습니다.
+
+## 제약사항
+
+- ALB와 NLB listener default action만 지원합니다.
+- NLB는 같은 listener 안에서 TCP/TLS/UDP target group을 섞을 수 없습니다.
+- weighted target groups는 같은 IP address type의 target group끼리 사용해야 합니다.
+- NLB weight 변경은 기존 연결이 아니라 새 flow부터 반영됩니다.
+- Goployer의 `canary.weight`는 percentage 값이라 `0`부터 `99`까지만 허용합니다.
+- `canary.bake_time`은 시간 대기만 수행합니다. CloudWatch alarm이나 API test 기반 자동 승격 판단은 별도 승격 조건으로 구성해야 합니다.
+
+## Commands
+
+Canary 배포 시작:
+
+```bash
+goployer deploy --manifest examples/manifests/canary-example.yaml --stack artd
+```
+
+Canary 배포 완료:
+
+```bash
+goployer deploy --manifest examples/manifests/canary-example.yaml --stack artd --complete-canary
+```

--- a/docs/content/ko/docs/Concepts/canary.md
+++ b/docs/content/ko/docs/Concepts/canary.md
@@ -18,6 +18,18 @@ Goployer의 canary 배포는 ALB/NLB weighted target groups를 사용합니다.
 
 현재 구현은 listener default action만 지원합니다. host/path 기반 listener rule canary는 아직 지원하지 않습니다.
 
+## Health check rollback
+
+Canary Auto Scaling group이 health check에 실패하거나 health check 단계에서 timeout되면, Goployer는 에러를 반환하기 전에 canary를 자동 rollback합니다.
+
+1. Listener default action을 original target group으로 복구합니다.
+2. Canary target group을 Auto Scaling group에서 분리하고 삭제합니다.
+3. 실패한 canary Auto Scaling group 크기를 `0`으로 줄입니다.
+4. 실패한 canary Auto Scaling group의 instance가 모두 없어질 때까지 기다립니다.
+5. 실패한 canary Auto Scaling group과 launch template을 삭제합니다.
+
+Rollback이 성공하면 이후 finish/cleanup 단계에서 실패한 canary가 승격되지 않도록 canary deploy step 상태를 해제합니다.
+
 ## Manifest
 
 ```yaml
@@ -48,6 +60,7 @@ regions:
 - NLB weight 변경은 기존 연결이 아니라 새 flow부터 반영됩니다.
 - Goployer의 `canary.weight`는 percentage 값이라 `0`부터 `90`까지만 허용합니다.
 - `canary.bake_time`은 시간 대기만 수행합니다. CloudWatch alarm이나 API test 기반 자동 승격 판단은 별도 승격 조건으로 구성해야 합니다.
+- 자동 rollback은 Goployer health check 실패에만 연결됩니다. 배포 명령이 종료된 뒤 CloudWatch alarm을 계속 감시하지는 않습니다.
 
 ## Commands
 

--- a/examples/manifests/canary-example.yaml
+++ b/examples/manifests/canary-example.yaml
@@ -1,0 +1,45 @@
+---
+name: hello
+userdata:
+  type: local
+  path: examples/scripts/userdata.sh
+
+tags:
+  - project=test
+  - repo=hello-deploy
+
+stacks:
+  - stack: artd
+    polling_interval: 30s
+    account: dev
+    env: dev
+    replacement_type: Canary
+    iam_instance_profile: app-hello-profile
+    ebs_optimized: true
+    capacity:
+      min: 4
+      max: 4
+      desired: 4
+    regions:
+      - region: ap-northeast-2
+        instance_type: t3.medium
+        ssh_key: test-master-key
+        ami_id: ami-01288945bd24ed49a
+        use_public_subnets: true
+        vpc: vpc-artd_apnortheast2
+        detailed_monitoring_enabled: false
+        security_groups:
+          - default-artd_apnortheast2
+        healthcheck_target_group: hello-artdapne2-ext
+        target_groups:
+          - hello-artdapne2-ext
+        canary:
+          load_balancer: hello-artdapne2-ext
+          listener_port: 443
+          listener_protocol: HTTPS
+          weight: 10
+          bake_time: 10m
+        availability_zones:
+          - ap-northeast-2a
+          - ap-northeast-2b
+          - ap-northeast-2c

--- a/examples/manifests/demoapp-xyzd-canary.yaml
+++ b/examples/manifests/demoapp-xyzd-canary.yaml
@@ -1,0 +1,46 @@
+---
+name: demoapp
+userdata:
+  type: local
+  path: examples/scripts/demoapp-userdata-canary.sh
+
+tags:
+  - project=demo
+  - repo=goployer
+
+stacks:
+  - stack: xyzd
+    polling_interval: 15s
+    account: dev
+    env: xyzd
+    replacement_type: Canary
+    iam_instance_profile: demoapp-profile
+    ebs_optimized: true
+    capacity:
+      min: 1
+      max: 1
+      desired: 1
+    regions:
+      - region: ap-northeast-2
+        instance_type: t3.micro
+        ami_id: ami-0276b9fe2b0768ef7
+        use_public_subnets: true
+        vpc: vpc-021c0886b3de5a28b
+        subnet_ids:
+          - subnet-0c0c3eea684e1df7b
+          - subnet-092c61b86a4d66ac8
+        detailed_monitoring_enabled: false
+        security_groups:
+          - demoapp-xyzd_apnortheast2-app
+        healthcheck_target_group: demoapp-xyzdapne2-ext
+        target_groups:
+          - demoapp-xyzdapne2-ext
+        canary:
+          load_balancer: demoapp-xyzdapne2-ext
+          listener_port: 443
+          listener_protocol: HTTPS
+          weight: 10
+          bake_time: 2m
+        availability_zones:
+          - ap-northeast-2a
+          - ap-northeast-2c

--- a/examples/manifests/demoapp-xyzd-stable.yaml
+++ b/examples/manifests/demoapp-xyzd-stable.yaml
@@ -1,0 +1,40 @@
+---
+name: demoapp
+userdata:
+  type: local
+  path: examples/scripts/demoapp-userdata.sh
+
+tags:
+  - project=demo
+  - repo=goployer
+
+stacks:
+  - stack: xyzd
+    polling_interval: 15s
+    account: dev
+    env: xyzd
+    replacement_type: BlueGreen
+    iam_instance_profile: demoapp-profile
+    ebs_optimized: true
+    capacity:
+      min: 1
+      max: 1
+      desired: 1
+    regions:
+      - region: ap-northeast-2
+        instance_type: t3.micro
+        ami_id: ami-0276b9fe2b0768ef7
+        use_public_subnets: true
+        vpc: vpc-021c0886b3de5a28b
+        subnet_ids:
+          - subnet-0c0c3eea684e1df7b
+          - subnet-092c61b86a4d66ac8
+        detailed_monitoring_enabled: false
+        security_groups:
+          - demoapp-xyzd_apnortheast2-app
+        healthcheck_target_group: demoapp-xyzdapne2-ext
+        target_groups:
+          - demoapp-xyzdapne2-ext
+        availability_zones:
+          - ap-northeast-2a
+          - ap-northeast-2c

--- a/examples/scripts/demoapp-userdata-canary.sh
+++ b/examples/scripts/demoapp-userdata-canary.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euxo pipefail
+
+dnf install -y python3
+
+mkdir -p /opt/demoapp
+cat >/opt/demoapp/app.py <<'PY'
+#!/usr/bin/env python3
+import json
+import os
+import socket
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+APP_VERSION = os.environ.get("APP_VERSION", "canary")
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/actuator/health":
+            self.reply({"status": "UP"})
+            return
+
+        self.reply({
+            "app": "demoapp",
+            "version": APP_VERSION,
+            "hostname": socket.gethostname(),
+            "path": self.path,
+        })
+
+    def log_message(self, fmt, *args):
+        return
+
+    def reply(self, body):
+        data = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+if __name__ == "__main__":
+    ThreadingHTTPServer(("0.0.0.0", 8080), Handler).serve_forever()
+PY
+
+cat >/etc/systemd/system/demoapp.service <<'UNIT'
+[Unit]
+Description=demoapp sample Python server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Environment=APP_VERSION=canary
+ExecStart=/usr/bin/python3 /opt/demoapp/app.py
+Restart=always
+RestartSec=2
+User=root
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now demoapp

--- a/examples/scripts/demoapp-userdata.sh
+++ b/examples/scripts/demoapp-userdata.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euxo pipefail
+
+dnf install -y python3
+
+mkdir -p /opt/demoapp
+cat >/opt/demoapp/app.py <<'PY'
+#!/usr/bin/env python3
+import json
+import os
+import socket
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+APP_VERSION = os.environ.get("APP_VERSION", "stable")
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/actuator/health":
+            self.reply({"status": "UP"})
+            return
+
+        self.reply({
+            "app": "demoapp",
+            "version": APP_VERSION,
+            "hostname": socket.gethostname(),
+            "path": self.path,
+        })
+
+    def log_message(self, fmt, *args):
+        return
+
+    def reply(self, body):
+        data = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+if __name__ == "__main__":
+    ThreadingHTTPServer(("0.0.0.0", 8080), Handler).serve_forever()
+PY
+
+cat >/etc/systemd/system/demoapp.service <<'UNIT'
+[Unit]
+Description=demoapp sample Python server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Environment=APP_VERSION=stable
+ExecStart=/usr/bin/python3 /opt/demoapp/app.py
+Restart=always
+RestartSec=2
+User=root
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now demoapp

--- a/pkg/aws/elbv2.go
+++ b/pkg/aws/elbv2.go
@@ -187,6 +187,21 @@ func (e ELBV2Client) DescribeLoadBalancers() ([]elbv2types.LoadBalancer, error) 
 	return result.LoadBalancers, nil
 }
 
+// GetLoadBalancerByName retrieves one load balancer by name.
+func (e ELBV2Client) GetLoadBalancerByName(name string) (*elbv2types.LoadBalancer, error) {
+	result, err := e.Client.DescribeLoadBalancers(context.Background(), &elbv2.DescribeLoadBalancersInput{
+		Names: []string{name},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(result.LoadBalancers) == 0 {
+		return nil, nil
+	}
+
+	return &result.LoadBalancers[0], nil
+}
+
 // GetMatchingLoadBalancer retrieves matching load balancer
 func (e ELBV2Client) GetMatchingLoadBalancer(lb string) (*elbv2types.LoadBalancer, error) {
 	input := &elbv2.DescribeLoadBalancersInput{
@@ -270,6 +285,38 @@ func (e ELBV2Client) ModifyListener(listenerArn *string, targetGroupArn string) 
 			},
 		},
 		ListenerArn: listenerArn,
+	}
+
+	_, err := e.Client.ModifyListener(context.Background(), input)
+	return err
+}
+
+// BuildWeightedForwardAction creates a forward action that splits traffic by target group weight.
+func BuildWeightedForwardAction(stableTargetGroupArn, canaryTargetGroupArn string, stableWeight, canaryWeight int32) elbv2types.Action {
+	return elbv2types.Action{
+		Type: elbv2types.ActionTypeEnumForward,
+		ForwardConfig: &elbv2types.ForwardActionConfig{
+			TargetGroups: []elbv2types.TargetGroupTuple{
+				{
+					TargetGroupArn: aws.String(stableTargetGroupArn),
+					Weight:         aws.Int32(stableWeight),
+				},
+				{
+					TargetGroupArn: aws.String(canaryTargetGroupArn),
+					Weight:         aws.Int32(canaryWeight),
+				},
+			},
+		},
+	}
+}
+
+// ModifyListenerWeightedForward modifies the default listener action to split traffic between target groups.
+func (e ELBV2Client) ModifyListenerWeightedForward(listenerArn, stableTargetGroupArn, canaryTargetGroupArn string, stableWeight, canaryWeight int32) error {
+	input := &elbv2.ModifyListenerInput{
+		DefaultActions: []elbv2types.Action{
+			BuildWeightedForwardAction(stableTargetGroupArn, canaryTargetGroupArn, stableWeight, canaryWeight),
+		},
+		ListenerArn: aws.String(listenerArn),
 	}
 
 	_, err := e.Client.ModifyListener(context.Background(), input)

--- a/pkg/aws/elbv2_test.go
+++ b/pkg/aws/elbv2_test.go
@@ -1,0 +1,47 @@
+/*
+copyright 2026 the Goployer authors
+
+licensed under the apache license, version 2.0 (the "license");
+you may not use this file except in compliance with the license.
+you may obtain a copy of the license at
+
+    http://www.apache.org/licenses/license-2.0
+
+unless required by applicable law or agreed to in writing, software
+distributed under the license is distributed on an "as is" basis,
+without warranties or conditions of any kind, either express or implied.
+see the license for the specific language governing permissions and
+limitations under the license.
+*/
+
+package aws
+
+import (
+	"testing"
+
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+)
+
+func TestBuildWeightedForwardAction(t *testing.T) {
+	action := BuildWeightedForwardAction("stable-tg", "canary-tg", 90, 10)
+
+	if action.Type != elbv2types.ActionTypeEnumForward {
+		t.Fatalf("expected forward action, got %s", action.Type)
+	}
+	if action.ForwardConfig == nil {
+		t.Fatal("expected forward config")
+	}
+	if len(action.ForwardConfig.TargetGroups) != 2 {
+		t.Fatalf("expected two target groups, got %d", len(action.ForwardConfig.TargetGroups))
+	}
+
+	stable := action.ForwardConfig.TargetGroups[0]
+	if *stable.TargetGroupArn != "stable-tg" || *stable.Weight != 90 {
+		t.Fatalf("unexpected stable target group: %#v", stable)
+	}
+
+	canary := action.ForwardConfig.TargetGroups[1]
+	if *canary.TargetGroupArn != "canary-tg" || *canary.Weight != 10 {
+		t.Fatalf("unexpected canary target group: %#v", canary)
+	}
+}

--- a/pkg/deployer/canary.go
+++ b/pkg/deployer/canary.go
@@ -22,8 +22,6 @@ import (
 	"strings"
 	"time"
 
-	astypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
-	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 
 	"github.com/DevopsArtFactory/goployer/pkg/aws"
@@ -37,11 +35,13 @@ import (
 type Canary struct {
 	PrevTargetGroups            map[string][]string
 	TargetGroups                map[string][]string
+	OriginalTargetGroupArn      map[string]string
+	CanaryTargetGroupArn        map[string]string
 	PrevHealthCheckTargetGroups map[string]string
-	LoadBalancer                map[string]string
-	LBSecurityGroup             map[string]*string
 	*Deployer
 }
+
+const defaultCanaryWeight = int64(10)
 
 // NewCanary creates new canary deployment deployer
 func NewCanary(h *helper.DeployerHelper) *Canary {
@@ -60,8 +60,8 @@ func NewCanary(h *helper.DeployerHelper) *Canary {
 		PrevHealthCheckTargetGroups: map[string]string{},
 		PrevTargetGroups:            map[string][]string{},
 		TargetGroups:                map[string][]string{},
-		LoadBalancer:                map[string]string{},
-		LBSecurityGroup:             map[string]*string{},
+		OriginalTargetGroupArn:      map[string]string{},
+		CanaryTargetGroupArn:        map[string]string{},
 		Deployer:                    &d,
 	}
 }
@@ -119,25 +119,13 @@ func (c *Canary) Deploy(config schemas.Config) error {
 			return err
 		}
 
-		// Check canary load balancer
-		lbSg, canaryLoadBalancer, err := c.GetLoadBalancerAndSecurityGroupForCanary(region, tgDetail, config.CompleteCanary)
-		if err != nil {
-			return err
-		}
-
-		// Create canary security group
-		err = c.GetEC2CanarySecurityGroup(tgDetail, region, lbSg, config.CompleteCanary)
-		if err != nil {
-			return err
-		}
-
 		switch config.CompleteCanary {
 		case true:
-			if err := c.CompleteCanaryDeployment(config, region, latestASG); err != nil {
+			if err := c.CompleteCanaryDeployment(config, region, latestASG, tgDetail); err != nil {
 				return err
 			}
 		case false:
-			changedRegionConfig, err := c.RunCanaryDeployment(config, region, tgDetail, canaryLoadBalancer, canaryVersion)
+			changedRegionConfig, err := c.RunCanaryDeployment(config, region, tgDetail, canaryVersion)
 			if err != nil {
 				return err
 			}
@@ -182,6 +170,12 @@ func (c *Canary) FinishAdditionalWork(config schemas.Config) error {
 	}
 
 	if config.CompleteCanary {
+		if err := c.ApplyCompleteCanaryWeights(config); err != nil {
+			return err
+		}
+		if err := c.DetachLatestCanaryResources(config); err != nil {
+			return err
+		}
 		c.StepStatus[constants.StepAdditionalWork] = true
 		return nil
 	}
@@ -189,16 +183,10 @@ func (c *Canary) FinishAdditionalWork(config schemas.Config) error {
 	skipped := len(config.Region) > 0 && !CheckRegionExist(config.Region, c.Stack.Regions)
 
 	if !skipped {
-		// attach to the previous target group
-		if len(c.PrevTargetGroups) > 0 {
-			if err := c.AttachToOriginalTargetGroups(config); err != nil {
-				return err
-			}
-
-			if err := c.HealthChecking(config); err != nil {
-				return err
-			}
+		if err := c.ApplyCanaryWeights(config); err != nil {
+			return err
 		}
+		c.WaitCanaryBakeTime(config)
 
 		if err := c.DoCommonAdditionalWork(config); err != nil {
 			return err
@@ -299,7 +287,7 @@ func (c *Canary) RunAPITest(config schemas.Config) error {
 		return nil
 	}
 
-	err := c.RunAPITest(config)
+	err := c.Deployer.RunAPITest(config)
 	if err != nil {
 		return err
 	}
@@ -312,6 +300,17 @@ func (c *Canary) RunAPITest(config schemas.Config) error {
 func (c *Canary) ValidateCanaryDeployment(config schemas.Config, region string) error {
 	if c.DeploymentFlag[region] != constants.CanaryDeployment && config.CompleteCanary {
 		return errors.New("you cannot complete canary deployment before start canary before")
+	}
+	for _, regionConfig := range c.Stack.Regions {
+		if regionConfig.Region != region {
+			continue
+		}
+		if regionConfig.Canary.ListenerARN == "" && (regionConfig.Canary.LoadBalancer == "" || regionConfig.Canary.ListenerPort == 0) {
+			return errors.New("canary.listener_arn or canary.load_balancer with canary.listener_port is required for canary deployment")
+		}
+		if regionConfig.Canary.Weight < 0 || regionConfig.Canary.Weight > 99 {
+			return errors.New("canary.weight must be between 0 and 99")
+		}
 	}
 
 	return nil
@@ -335,21 +334,6 @@ func (c *Canary) CopyTargetGroups(tg *elbv2types.TargetGroup, canaryTgName, regi
 // GenerateCanaryTargetGroupName generates name of canary target group for canary
 func (c *Canary) GenerateCanaryTargetGroupName(canaryVersion int) string {
 	return fmt.Sprintf("%s-%s-canary-v%03d", c.AwsConfig.Name, c.Stack.Env, canaryVersion+1)
-}
-
-// GenerateCanaryLoadBalancerName generates name of canary load balancer for canary
-func (c *Canary) GenerateCanaryLoadBalancerName(region string) string {
-	return fmt.Sprintf("%s-%s-%s-%s", c.AwsConfig.Name, c.Stack.Env, strings.ReplaceAll(region, "-", ""), constants.CanaryMark)
-}
-
-// GenerateCanarySecurityGroupName generates name of canary load balancer for canary
-func (c *Canary) GenerateCanarySecurityGroupName(region string) string {
-	return fmt.Sprintf("%s-%s-%s-%s", c.AwsConfig.Name, c.Stack.Env, strings.ReplaceAll(region, "-", ""), constants.CanaryMark)
-}
-
-// GenerateCanaryLBSecurityGroupName generates name of canary load balancer for canary
-func (c *Canary) GenerateCanaryLBSecurityGroupName(region string) string {
-	return fmt.Sprintf("%s-%s-%s-lb-%s", c.AwsConfig.Name, c.Stack.Env, strings.ReplaceAll(region, "-", ""), constants.CanaryMark)
 }
 
 // GetAsgTargetGroups retrieves target group list of autoscaling group
@@ -431,6 +415,29 @@ func (c *Canary) AttachToOriginalTargetGroups(config schemas.Config) error {
 	return nil
 }
 
+// TargetGroupARNsForRegion returns original target groups from manifest for a region.
+func (c *Canary) TargetGroupARNsForRegion(region schemas.RegionConfig) ([]string, error) {
+	targetGroups := c.GetTargetGroupNames(region)
+	if len(targetGroups) == 0 {
+		return nil, fmt.Errorf("there is no target group specified")
+	}
+
+	client, err := selectClientFromList(c.AWSClients, region.Region)
+	if err != nil {
+		return nil, err
+	}
+
+	targetGroupARNs, err := client.ELBV2Service.GetTargetGroupARNs(targetGroups)
+	if err != nil {
+		return nil, err
+	}
+	if targetGroupARNs == nil {
+		return nil, fmt.Errorf("there is no target group specified")
+	}
+
+	return targetGroupARNs, nil
+}
+
 // ChangeTargetGroupInfo changes existing target group to the new one for canary deployment
 func (c *Canary) ChangeTargetGroupInfo(newTgName string, region schemas.RegionConfig) schemas.RegionConfig {
 	if len(region.HealthcheckTargetGroup) > 0 {
@@ -443,6 +450,146 @@ func (c *Canary) ChangeTargetGroupInfo(newTgName string, region schemas.RegionCo
 	}
 	region.TargetGroups = []string{newTgName}
 	return region
+}
+
+// CanaryWeights returns stable/canary weights for listener default actions.
+func CanaryWeights(region schemas.RegionConfig, completeCanary bool) (int32, int32) {
+	if completeCanary {
+		return 100, 0
+	}
+
+	weight := region.Canary.Weight
+	if weight == 0 {
+		weight = defaultCanaryWeight
+	}
+
+	return int32(100 - weight), int32(weight)
+}
+
+// ResolveCanaryListenerARN resolves the listener from either ARN or load balancer name plus port.
+func (c *Canary) ResolveCanaryListenerARN(region schemas.RegionConfig, client aws.Client) (string, error) {
+	if region.Canary.ListenerARN != "" {
+		return region.Canary.ListenerARN, nil
+	}
+
+	lb, err := client.ELBV2Service.GetLoadBalancerByName(region.Canary.LoadBalancer)
+	if err != nil {
+		return "", err
+	}
+	if lb == nil {
+		return "", fmt.Errorf("canary load balancer not found: %s", region.Canary.LoadBalancer)
+	}
+
+	listeners, err := client.ELBV2Service.DescribeListeners(*lb.LoadBalancerArn)
+	if err != nil {
+		return "", err
+	}
+	for _, listener := range listeners {
+		if listener.Port == nil || *listener.Port != region.Canary.ListenerPort {
+			continue
+		}
+		if region.Canary.ListenerProtocol != "" && !strings.EqualFold(string(listener.Protocol), region.Canary.ListenerProtocol) {
+			continue
+		}
+		if listener.ListenerArn == nil {
+			break
+		}
+		return *listener.ListenerArn, nil
+	}
+
+	return "", fmt.Errorf("canary listener not found: %s:%d", region.Canary.LoadBalancer, region.Canary.ListenerPort)
+}
+
+// ApplyCanaryWeights sends the configured percentage of listener traffic to canary target groups.
+func (c *Canary) ApplyCanaryWeights(config schemas.Config) error {
+	for _, region := range c.Stack.Regions {
+		if config.Region != "" && config.Region != region.Region {
+			c.Logger.Debug("This region is skipped by user : " + region.Region)
+			continue
+		}
+
+		stableWeight, canaryWeight := CanaryWeights(region, false)
+		if err := c.ModifyWeightedListener(region, stableWeight, canaryWeight); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// WaitCanaryBakeTime keeps the canary weight active before the deploy command exits.
+func (c *Canary) WaitCanaryBakeTime(config schemas.Config) {
+	for _, region := range c.Stack.Regions {
+		if config.Region != "" && config.Region != region.Region {
+			continue
+		}
+		if region.Canary.BakeTime <= 0 {
+			continue
+		}
+
+		c.Logger.Infof("Waiting canary bake time in %s: %s", region.Region, region.Canary.BakeTime)
+		time.Sleep(region.Canary.BakeTime)
+	}
+}
+
+// ApplyCompleteCanaryWeights restores all listener traffic to the original target group.
+func (c *Canary) ApplyCompleteCanaryWeights(config schemas.Config) error {
+	for _, region := range c.Stack.Regions {
+		if config.Region != "" && config.Region != region.Region {
+			c.Logger.Debug("This region is skipped by user : " + region.Region)
+			continue
+		}
+
+		stableWeight, canaryWeight := CanaryWeights(region, true)
+		if err := c.ModifyListenerToStableTargetGroup(region, stableWeight, canaryWeight); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ModifyWeightedListener updates the existing ALB listener's default action.
+func (c *Canary) ModifyWeightedListener(region schemas.RegionConfig, stableWeight, canaryWeight int32) error {
+	stableTargetGroupArn := c.OriginalTargetGroupArn[region.Region]
+	canaryTargetGroupArn := c.CanaryTargetGroupArn[region.Region]
+	if stableTargetGroupArn == "" || canaryTargetGroupArn == "" {
+		return fmt.Errorf("canary target group information is missing for %s", region.Region)
+	}
+
+	client, err := selectClientFromList(c.AWSClients, region.Region)
+	if err != nil {
+		return err
+	}
+
+	listenerArn, err := c.ResolveCanaryListenerARN(region, client)
+	if err != nil {
+		return err
+	}
+
+	c.Logger.Infof("Changing canary listener weights in %s: stable=%d, canary=%d", region.Region, stableWeight, canaryWeight)
+	return client.ELBV2Service.ModifyListenerWeightedForward(listenerArn, stableTargetGroupArn, canaryTargetGroupArn, stableWeight, canaryWeight)
+}
+
+// ModifyListenerToStableTargetGroup restores the listener default action to the original target group.
+func (c *Canary) ModifyListenerToStableTargetGroup(region schemas.RegionConfig, stableWeight, canaryWeight int32) error {
+	stableTargetGroupArn := c.OriginalTargetGroupArn[region.Region]
+	if stableTargetGroupArn == "" {
+		return fmt.Errorf("stable target group information is missing for %s", region.Region)
+	}
+
+	client, err := selectClientFromList(c.AWSClients, region.Region)
+	if err != nil {
+		return err
+	}
+
+	listenerArn, err := c.ResolveCanaryListenerARN(region, client)
+	if err != nil {
+		return err
+	}
+
+	c.Logger.Infof("Restoring canary listener weights in %s: stable=%d, canary=%d", region.Region, stableWeight, canaryWeight)
+	return client.ELBV2Service.ModifyListener(&listenerArn, stableTargetGroupArn)
 }
 
 // CleanChecking checks Termination status
@@ -477,32 +624,6 @@ func (c *Canary) CleanChecking(config schemas.Config) error {
 	return nil
 }
 
-// FindCanaryLoadBalancer finds if there is canary-related load balancer
-func (c *Canary) FindCanaryLoadBalancer(region schemas.RegionConfig) (*elbv2types.LoadBalancer, error) {
-	client, err := selectClientFromList(c.AWSClients, region.Region)
-	if err != nil {
-		return nil, err
-	}
-
-	loadBalancers, err := client.ELBV2Service.DescribeLoadBalancers()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, lb := range loadBalancers {
-		if c.CheckValidCanaryLB(c.AwsConfig.Name, *lb.LoadBalancerName) {
-			return &lb, nil
-		}
-	}
-
-	return nil, nil
-}
-
-// CheckValidCanaryLB checks if load balancer is canary-related or not
-func (c *Canary) CheckValidCanaryLB(app, lb string) bool {
-	return strings.HasPrefix(lb, app) && strings.Contains(lb, constants.CanaryMark)
-}
-
 // CheckCanaryVersion checks latest version of canary target group
 func CheckCanaryVersion(tgs []string, region string) int {
 	latestVersion := 0
@@ -517,176 +638,6 @@ func CheckCanaryVersion(tgs []string, region string) int {
 	}
 
 	return latestVersion
-}
-
-// CreateCanaryLoadBalancer creates a new load balancer for canary
-func (c *Canary) CreateCanaryLoadBalancer(region schemas.RegionConfig, groupID *string) (*elbv2types.LoadBalancer, error) {
-	client, err := selectClientFromList(c.AWSClients, region.Region)
-	if err != nil {
-		return nil, err
-	}
-
-	newLBName := c.GenerateCanaryLoadBalancerName(region.Region)
-
-	availabilityZones, err := client.EC2Service.GetAvailabilityZones(region.VPC, region.AvailabilityZones)
-	if err != nil {
-		return nil, err
-	}
-
-	subnets := region.SubnetIDs
-	if len(subnets) == 0 {
-		c.Logger.Info("Not Subnet ID Specific")
-		subnets, err = client.EC2Service.GetSubnets(region.VPC, region.UsePublicSubnets, availabilityZones)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		subnetIds := strings.Join(subnets, " ")
-		c.Logger.Infof("Subnet ID are Specific : %s", subnetIds)
-	}
-
-	lb, err := client.ELBV2Service.CreateLoadBalancer(newLBName, subnets, groupID)
-	if err != nil {
-		return nil, err
-	}
-
-	return lb, nil
-}
-
-// AttachCanaryTargetGroup attaches target group to load balancer
-func (c *Canary) AttachCanaryTargetGroup(lbArn, tgArn string, region schemas.RegionConfig) error {
-	client, err := selectClientFromList(c.AWSClients, region.Region)
-	if err != nil {
-		return err
-	}
-
-	existingListeners, err := client.ELBV2Service.DescribeListeners(lbArn)
-	if err != nil {
-		return err
-	}
-
-	if len(existingListeners) == 0 {
-		return client.ELBV2Service.CreateNewListener(lbArn, tgArn)
-	}
-
-	return client.ELBV2Service.ModifyListener(existingListeners[0].ListenerArn, tgArn)
-}
-
-// GetEC2CanarySecurityGroup creates a new security group for canary
-func (c *Canary) GetEC2CanarySecurityGroup(tg *elbv2types.TargetGroup, region schemas.RegionConfig, lbSg *string, completeCanary bool) error {
-	client, err := selectClientFromList(c.AWSClients, region.Region)
-	if err != nil {
-		return err
-	}
-
-	newSGName := c.GenerateCanarySecurityGroupName(region.Region)
-
-	if completeCanary {
-		groupID, err := client.EC2Service.GetSecurityGroup(newSGName)
-		if err != nil {
-			return err
-		}
-		c.SecurityGroup[region.Region] = groupID
-		c.Logger.Debugf("Found existing security group id: %s", *groupID)
-
-		return nil
-	}
-
-	duplicated := false
-	groupID, err := client.EC2Service.CreateSecurityGroup(newSGName, tg.VpcId)
-	if err != nil {
-		if strings.Contains(err.Error(), "InvalidGroup.Duplicate") {
-			c.Logger.Debugf("Security group is already created: %s", newSGName)
-			duplicated = true
-		}
-
-		if !duplicated {
-			return err
-		}
-	}
-
-	if duplicated {
-		groupID, err = client.EC2Service.GetSecurityGroup(newSGName)
-		if err != nil {
-			return err
-		}
-		c.Logger.Debugf("Found existing security group id: %s", *groupID)
-	} else if err := client.EC2Service.UpdateOutboundRules(*groupID, "-1", "0.0.0.0/0", "outbound to internet", -1, -1); err != nil {
-		c.Logger.Warn(err.Error())
-	}
-
-	// inbound
-	if err := client.EC2Service.UpdateInboundRulesWithGroup(*groupID, "tcp", "Allow access from canary load balancer", lbSg, int64(*tg.Port), int64(*tg.Port)); err != nil {
-		c.Logger.Warn(err.Error())
-	}
-
-	c.SecurityGroup[region.Region] = groupID
-	c.Logger.Debugf("Security group for this canary deployment: %s", *groupID)
-
-	return nil
-}
-
-// GetCanaryLoadBalancerSecurityGroup retrieves existing load balancer security group for canary
-func (c *Canary) GetCanaryLoadBalancerSecurityGroup(region schemas.RegionConfig) (*string, error) {
-	client, err := selectClientFromList(c.AWSClients, region.Region)
-	if err != nil {
-		return nil, err
-	}
-
-	newLBName := c.GenerateCanaryLBSecurityGroupName(region.Region)
-
-	groupID, err := client.EC2Service.GetSecurityGroup(newLBName)
-	if err != nil {
-		c.Logger.Warn(err.Error())
-		return nil, nil
-	}
-
-	c.Logger.Debugf("Found existing lb security group id: %s", *groupID)
-
-	return groupID, nil
-}
-
-// CreateCanaryLBSecurityGroup creates a new security group for canary
-func (c *Canary) CreateCanaryLBSecurityGroup(tg *elbv2types.TargetGroup, region schemas.RegionConfig) (*string, error) {
-	client, err := selectClientFromList(c.AWSClients, region.Region)
-	if err != nil {
-		return nil, err
-	}
-
-	lbSGName := c.GenerateCanaryLBSecurityGroupName(region.Region)
-
-	duplicated := false
-	groupID, err := client.EC2Service.CreateSecurityGroup(lbSGName, tg.VpcId)
-	if err != nil {
-		if strings.Contains(err.Error(), "InvalidGroup.Duplicate") {
-			c.Logger.Debugf("Security group is already created: %s", lbSGName)
-			duplicated = true
-		}
-		if !duplicated {
-			return nil, err
-		}
-	}
-
-	if duplicated {
-		groupID, err = client.EC2Service.GetSecurityGroup(lbSGName)
-		if err != nil {
-			return nil, err
-		}
-
-		c.Logger.Debugf("Found existing security group id: %s", *groupID)
-	}
-
-	// inbound
-	if err := client.EC2Service.UpdateInboundRules(*groupID, "tcp", "0.0.0.0/0", "inbound from internet", 80, 80); err != nil {
-		c.Logger.Warn(err.Error())
-	}
-
-	// outbound
-	if err := client.EC2Service.UpdateOutboundRules(*groupID, "-1", "0.0.0.0/0", "outbound to internet", -1, -1); err != nil {
-		c.Logger.Warn(err.Error())
-	}
-
-	return groupID, nil
 }
 
 // ReduceOriginalAutoscalingGroupCount set existing autoscaling group count to -1
@@ -768,148 +719,6 @@ func (c *Canary) CleanPreviousCanaryResources(region schemas.RegionConfig, compl
 		}
 	}
 
-	c.Logger.Debugf("Start to delete load balancer and security group for canary")
-	if completeCanary {
-		if err := c.DeleteLoadBalancer(region); err != nil {
-			return err
-		}
-
-		if err := c.LoadBalancerDeletionChecking(region); err != nil {
-			return err
-		}
-
-		if err := c.DeleteEC2IngressRules(region); err != nil {
-			return err
-		}
-
-		if err := c.DeleteEC2SecurityGroup(region); err != nil {
-			return err
-		}
-
-		if err := c.DeleteLBSecurityGroup(region); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// DeleteLoadBalancer deletes load balancer
-func (c *Canary) DeleteLoadBalancer(region schemas.RegionConfig) error {
-	if len(c.LoadBalancer[region.Region]) == 0 {
-		c.Logger.Debugf("No load balancer to delete")
-		return nil
-	}
-
-	client, err := selectClientFromList(c.AWSClients, region.Region)
-	if err != nil {
-		return err
-	}
-
-	err = client.ELBV2Service.DeleteLoadBalancer(c.LoadBalancer[region.Region])
-	if err != nil {
-		return err
-	}
-
-	c.Logger.Debugf("Delete load balancer: %s", c.LoadBalancer[region.Region])
-
-	return nil
-}
-
-// DeleteLBSecurityGroup deletes load balancer security group
-func (c *Canary) DeleteLBSecurityGroup(region schemas.RegionConfig) error {
-	if c.LBSecurityGroup[region.Region] == nil {
-		c.Logger.Debugf("No lb security group to delete")
-		return nil
-	}
-
-	client, err := selectClientFromList(c.AWSClients, region.Region)
-	if err != nil {
-		return err
-	}
-
-	c.Logger.Debug("Wait 30 seconds until load balancer is successfully terminated")
-	time.Sleep(30 * time.Second)
-
-	retry := int64(4)
-	for {
-		err = client.EC2Service.DeleteSecurityGroup(*c.LBSecurityGroup[region.Region])
-		if err != nil {
-			if retry > 0 {
-				retry--
-				c.Logger.Debugf("error occurred on lb deletion and remained retry count is %d", retry)
-				time.Sleep(time.Duration(1+5*(3-retry)) * time.Second)
-			} else {
-				return err
-			}
-		}
-
-		if err == nil {
-			break
-		}
-	}
-	c.Logger.Debugf("Delete load balancer security group: %s", *c.LBSecurityGroup[region.Region])
-
-	return nil
-}
-
-// DeleteEC2SecurityGroup deletes EC2 security group for canary
-func (c *Canary) DeleteEC2SecurityGroup(region schemas.RegionConfig) error {
-	if c.SecurityGroup[region.Region] == nil {
-		c.Logger.Debugf("No EC2 security group to delete")
-		return nil
-	}
-
-	client, err := selectClientFromList(c.AWSClients, region.Region)
-	if err != nil {
-		return err
-	}
-
-	err = client.EC2Service.DeleteSecurityGroup(*c.SecurityGroup[region.Region])
-	if err != nil {
-		return err
-	}
-
-	c.Logger.Debugf("Delete canary EC2 security group: %s", *c.SecurityGroup[region.Region])
-
-	return nil
-}
-
-// DeleteEC2IngressRules deletes ingress rules for EC2
-func (c *Canary) DeleteEC2IngressRules(region schemas.RegionConfig) error {
-	if c.SecurityGroup[region.Region] == nil {
-		c.Logger.Debugf("No EC2 security group to delete")
-		return nil
-	}
-
-	client, err := selectClientFromList(c.AWSClients, region.Region)
-	if err != nil {
-		return err
-	}
-
-	// inbound
-	sgDetails, err := client.EC2Service.GetSecurityGroupDetails([]string{*c.SecurityGroup[region.Region]})
-	if err != nil {
-		return err
-	}
-
-	if len(sgDetails) != 1 {
-		return fmt.Errorf("delete ec2 ingress error because more than one or no security group detected: %d", len(sgDetails))
-	}
-
-	sgID := sgDetails[0].GroupId
-	for _, in := range sgDetails[0].IpPermissions {
-		if len(in.UserIdGroupPairs) > 0 {
-			for _, uip := range in.UserIdGroupPairs {
-				if err := client.EC2Service.RevokeInboundRulesWithGroup(*sgID, *in.IpProtocol, uip.GroupId, int64(*in.FromPort), int64(*in.ToPort)); err != nil {
-					c.Logger.Warn(err.Error())
-				}
-			}
-		}
-	}
-
-	c.Logger.Debugf("Detach lb security group from EC2 security group: %s", *c.SecurityGroup[region.Region])
-
 	return nil
 }
 
@@ -953,68 +762,47 @@ func (c *Canary) DetachCanaryTargetGroup(asg string, region schemas.RegionConfig
 	return nil
 }
 
-// DetachSecurityGroup deletes lb security groups from instances
-func (c *Canary) DetachSecurityGroup(nis []ec2types.InstanceNetworkInterface, region schemas.RegionConfig, excludeSg string) error {
-	client, err := selectClientFromList(c.AWSClients, region.Region)
-	if err != nil {
-		return err
-	}
-
-	for _, ni := range nis {
-		var sgs []string
-		for _, group := range ni.Groups {
-			if *group.GroupId != excludeSg {
-				sgs = append(sgs, *group.GroupId)
-			}
+// DetachLatestCanaryResources detaches and deletes the canary target group after listener restore.
+func (c *Canary) DetachLatestCanaryResources(config schemas.Config) error {
+	for _, region := range c.Stack.Regions {
+		if config.Region != "" && config.Region != region.Region {
+			c.Logger.Debug("This region is skipped by user : " + region.Region)
+			continue
 		}
-		if len(sgs) > 0 {
-			err = client.EC2Service.ModifyNetworkInterfaces(ni.NetworkInterfaceId, sgs)
-			if err != nil {
+
+		canaryTargetGroupArn := c.CanaryTargetGroupArn[region.Region]
+		if canaryTargetGroupArn == "" {
+			continue
+		}
+
+		latestASG := c.LatestAsg[region.Region]
+		if latestASG != "" {
+			if err := c.DetachCanaryTargetGroup(latestASG, region, []string{canaryTargetGroupArn}); err != nil {
 				return err
 			}
-
-			c.Logger.Debugf("Remove security group from eni: %s", *ni.NetworkInterfaceId)
 		}
-	}
 
-	return nil
-}
-
-// ChangeLaunchTemplateVersion changes launch template to the new version
-func (c *Canary) ChangeLaunchTemplateVersion(asg string, lt *astypes.LaunchTemplateSpecification, region schemas.RegionConfig, excludeSg string) error {
-	client, err := selectClientFromList(c.AWSClients, region.Region)
-	if err != nil {
-		return err
-	}
-
-	ltDetail, err := client.EC2Service.GetMatchingLaunchTemplate(*lt.LaunchTemplateId)
-	if err != nil {
-		return err
-	}
-	c.Logger.Debugf("Retrieved previous version of launch template of launch template: %s", *lt.LaunchTemplateId)
-
-	var sgs []string
-	for _, sg := range ltDetail.LaunchTemplateData.SecurityGroupIds {
-		if sg != excludeSg {
-			sgs = append(sgs, sg)
+		client, err := selectClientFromList(c.AWSClients, region.Region)
+		if err != nil {
+			return err
 		}
-	}
+		if err := client.ELBV2Service.DeleteTargetGroup(&canaryTargetGroupArn); err != nil {
+			return err
+		}
+		c.Logger.Debugf("Deleted canary target group: %s", canaryTargetGroupArn)
 
-	ret, err := client.EC2Service.CreateNewLaunchTemplateVersion(ltDetail, sgs)
-	if err != nil {
-		return err
-	}
-	c.Logger.Debugf("Created new version of launch template: %s - version%d", *ret.LaunchTemplateId, *ret.VersionNumber)
-
-	if err := client.EC2Service.UpdateAutoScalingLaunchTemplate(asg, ret); err != nil {
-		return err
+		if latestASG != "" {
+			if err := c.RemoveCanaryTag(latestASG, region); err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil
 }
 
 // RunCanaryDeployment runs canary deployment
-func (c *Canary) RunCanaryDeployment(config schemas.Config, region schemas.RegionConfig, tgDetail *elbv2types.TargetGroup, canaryLoadBalancer *elbv2types.LoadBalancer, canaryVersion int) (schemas.RegionConfig, error) {
+func (c *Canary) RunCanaryDeployment(config schemas.Config, region schemas.RegionConfig, tgDetail *elbv2types.TargetGroup, canaryVersion int) (schemas.RegionConfig, error) {
 	newTgName := c.GenerateCanaryTargetGroupName(canaryVersion)
 	c.Logger.Debugf("New target group will be created for canary deployment: %s", newTgName)
 
@@ -1023,11 +811,8 @@ func (c *Canary) RunCanaryDeployment(config schemas.Config, region schemas.Regio
 		return region, err
 	}
 	c.Logger.Debugf("New target group is created: %s", *tg.TargetGroupName)
-
-	if err := c.AttachCanaryTargetGroup(*canaryLoadBalancer.LoadBalancerArn, *tg.TargetGroupArn, region); err != nil {
-		return region, err
-	}
-	c.Logger.Debugf("Attached target group to load balancer: %s", *canaryLoadBalancer.LoadBalancerName)
+	c.OriginalTargetGroupArn[region.Region] = *tgDetail.TargetGroupArn
+	c.CanaryTargetGroupArn[region.Region] = *tg.TargetGroupArn
 
 	c.Logger.Debugf("Change target group information with new target group: %s", newTgName)
 	region = c.ChangeTargetGroupInfo(newTgName, region)
@@ -1037,11 +822,15 @@ func (c *Canary) RunCanaryDeployment(config schemas.Config, region schemas.Regio
 		return region, err
 	}
 
+	if err := c.ModifyWeightedListener(region, 100, 0); err != nil {
+		return region, err
+	}
+
 	return region, nil
 }
 
 // CompleteCanaryDeployment completes canary deployment
-func (c *Canary) CompleteCanaryDeployment(config schemas.Config, region schemas.RegionConfig, latestASG string) error {
+func (c *Canary) CompleteCanaryDeployment(config schemas.Config, region schemas.RegionConfig, latestASG string, canaryTGDetail *elbv2types.TargetGroup) error {
 	asgDetail, err := c.DescribeAutoScalingGroup(latestASG, region.Region)
 	if err != nil {
 		return err
@@ -1051,27 +840,22 @@ func (c *Canary) CompleteCanaryDeployment(config schemas.Config, region schemas.
 		return fmt.Errorf("no autoscaling group information retrieved. Please check autoscaling group resource: %s", latestASG)
 	}
 
-	instanceIds := extractInstanceIds(asgDetail)
-	instancesDetail, err := c.DescribeInstances(instanceIds, region)
+	originalTGDetail, err := c.DescribeTargetGroup(region.HealthcheckTargetGroup, region.Region)
 	if err != nil {
 		return err
 	}
+	c.OriginalTargetGroupArn[region.Region] = *originalTGDetail.TargetGroupArn
+	c.CanaryTargetGroupArn[region.Region] = *canaryTGDetail.TargetGroupArn
 
-	nis := getNetworkInterfaces(instancesDetail)
-
-	if err := c.DetachSecurityGroup(nis, region, *c.SecurityGroup[region.Region]); err != nil {
+	targetGroupARNs, err := c.TargetGroupARNsForRegion(region)
+	if err != nil {
 		return err
 	}
-
-	if err := c.RemoveCanaryTag(latestASG, region); err != nil {
+	client, err := selectClientFromList(c.AWSClients, region.Region)
+	if err != nil {
 		return err
 	}
-
-	if err := c.DetachCanaryTargetGroup(latestASG, region, asgDetail.TargetGroupARNs); err != nil {
-		return err
-	}
-
-	if err := c.ChangeLaunchTemplateVersion(latestASG, asgDetail.LaunchTemplate, region, *c.SecurityGroup[region.Region]); err != nil {
+	if err := client.EC2Service.AttachAsgToTargetGroups(latestASG, targetGroupARNs); err != nil {
 		return err
 	}
 
@@ -1087,106 +871,19 @@ func (c *Canary) CompleteCanaryDeployment(config schemas.Config, region schemas.
 
 	// settings for health checking
 	c.Stack.Capacity.Desired = appliedCapacity.Desired
+	c.AppliedCapacity = &appliedCapacity
 	c.AsgNames[region.Region] = latestASG
+	c.PrevAsgs[region.Region] = withoutString(c.PrevAsgs[region.Region], latestASG)
 
 	return nil
 }
 
-// GetLoadBalancerAndSecurityGroupForCanary gets load balancer and security group for canary deployment
-func (c *Canary) GetLoadBalancerAndSecurityGroupForCanary(region schemas.RegionConfig, tgDetail *elbv2types.TargetGroup, completeCanary bool) (*string, *elbv2types.LoadBalancer, error) {
-	canaryLoadBalancer, err := c.FindCanaryLoadBalancer(region)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var lbSg *string
-	if len(region.HealthcheckLB) > 0 || len(region.TargetGroups) > 0 {
-		if canaryLoadBalancer == nil {
-			if !completeCanary {
-				lbSg, err := c.CreateCanaryLBSecurityGroup(tgDetail, region)
-				if err != nil {
-					return nil, nil, err
-				}
-
-				canaryLoadBalancer, err = c.CreateCanaryLoadBalancer(region, lbSg)
-				if err != nil {
-					return nil, nil, err
-				}
-				c.Logger.Debugf("Created a new load balancer for canary: %s", *canaryLoadBalancer.LoadBalancerName)
-			}
-		} else {
-			c.Logger.Debugf("Found existing load balancer for canary: %s", *canaryLoadBalancer.LoadBalancerName)
-			lbSg, err = c.GetCanaryLoadBalancerSecurityGroup(region)
-			if err != nil {
-				return nil, nil, err
-			}
-		}
-
-		if lbSg == nil && !completeCanary {
-			lbSg, err = c.CreateCanaryLBSecurityGroup(tgDetail, region)
-			if err != nil {
-				return nil, nil, err
-			}
-			c.Logger.Debugf("New lb security group is created: %s", *lbSg)
+func withoutString(values []string, target string) []string {
+	ret := values[:0]
+	for _, value := range values {
+		if value != target {
+			ret = append(ret, value)
 		}
 	}
-
-	c.LBSecurityGroup[region.Region] = lbSg
-	if canaryLoadBalancer != nil {
-		c.LoadBalancer[region.Region] = *canaryLoadBalancer.LoadBalancerArn
-	}
-
-	return lbSg, canaryLoadBalancer, nil
-}
-
-// LoadBalancerDeletionChecking checks if load balancer is deleted well or not
-func (c *Canary) LoadBalancerDeletionChecking(region schemas.RegionConfig) error {
-	if len(c.LoadBalancer[region.Region]) == 0 {
-		c.Logger.Debugf("No load balancer to delete")
-		return nil
-	}
-
-	client, err := selectClientFromList(c.AWSClients, region.Region)
-	if err != nil {
-		return err
-	}
-
-	done := false
-	for !done {
-		lb, err := client.ELBV2Service.GetMatchingLoadBalancer(c.LoadBalancer[region.Region])
-		if err != nil {
-			return err
-		}
-
-		if lb == nil {
-			c.Logger.Debugf("Canary load balancer is deleted: %s", c.LoadBalancer[region.Region])
-			done = true
-		} else {
-			time.Sleep(10 * time.Second)
-		}
-	}
-
-	return nil
-}
-
-// extractInstanceIds gathers pointer of instance's id and make slice with them
-func extractInstanceIds(asgDetail *astypes.AutoScalingGroup) []string {
-	var instanceIds []string
-	for _, ins := range asgDetail.Instances {
-		instanceIds = append(instanceIds, *ins.InstanceId)
-	}
-
-	return instanceIds
-}
-
-// getNetworkInterfaces gathers all network interfaces from EC2 instances
-func getNetworkInterfaces(instances []ec2types.Instance) []ec2types.InstanceNetworkInterface {
-	var nis []ec2types.InstanceNetworkInterface
-	for _, instance := range instances {
-		if instance.NetworkInterfaces != nil {
-			nis = append(nis, instance.NetworkInterfaces...)
-		}
-	}
-
-	return nis
+	return ret
 }

--- a/pkg/deployer/canary.go
+++ b/pkg/deployer/canary.go
@@ -148,12 +148,19 @@ func (c *Canary) HealthChecking(config schemas.Config) error {
 		c.Logger.Debugf("Start Timestamp: %d, timeout: %s", config.StartTimestamp, config.Timeout)
 		isTimeout, _ := tool.CheckTimeout(config.StartTimestamp, config.Timeout)
 		if isTimeout {
-			return fmt.Errorf("timeout has been exceeded : %.0f minutes", config.Timeout.Minutes())
+			err := fmt.Errorf("timeout has been exceeded : %.0f minutes", config.Timeout.Minutes())
+			if rollbackErr := c.RollbackCanaryDeployment(config); rollbackErr != nil {
+				return fmt.Errorf("%w; rollback failed: %s", err, rollbackErr)
+			}
+			return err
 		}
 
 		isDone, err := c.Deployer.HealthChecking(config)
 		if err != nil {
-			return errors.New("error happened while health checking")
+			if rollbackErr := c.RollbackCanaryDeployment(config); rollbackErr != nil {
+				return fmt.Errorf("error happened while health checking: %w; rollback failed: %s", err, rollbackErr)
+			}
+			return fmt.Errorf("error happened while health checking: %w", err)
 		}
 
 		if isDone {
@@ -164,6 +171,104 @@ func (c *Canary) HealthChecking(config schemas.Config) error {
 	}
 
 	return nil
+}
+
+// ShouldRollbackCanary returns whether a failed health check owns canary resources to clean up.
+func (c *Canary) ShouldRollbackCanary(config schemas.Config) bool {
+	return c.StepStatus[constants.StepDeploy] && !config.CompleteCanary
+}
+
+// RollbackCanaryDeployment restores listener traffic and removes failed canary resources.
+func (c *Canary) RollbackCanaryDeployment(config schemas.Config) error {
+	if !c.ShouldRollbackCanary(config) {
+		return nil
+	}
+
+	var retErr error
+	recordErr := func(err error) {
+		if err != nil && retErr == nil {
+			retErr = err
+		}
+	}
+	rollbackStartTimestamp := time.Now().Unix()
+
+	for _, region := range c.Stack.Regions {
+		if config.Region != "" && config.Region != region.Region {
+			c.Logger.Debug("This region is skipped by user : " + region.Region)
+			continue
+		}
+
+		if c.OriginalTargetGroupArn[region.Region] != "" {
+			if err := c.ModifyListenerToStableTargetGroup(region, 100, 0); err != nil {
+				recordErr(err)
+				continue
+			}
+		} else {
+			recordErr(fmt.Errorf("original target group is missing for rollback region: %s", region.Region))
+			continue
+		}
+
+		canaryASG := c.ActiveCanaryAutoScalingGroupName(region.Region)
+		if canaryASG == "" {
+			recordErr(fmt.Errorf("active canary autoscaling group is missing for rollback region: %s", region.Region))
+			continue
+		}
+
+		if err := c.DetachLatestCanaryResources(schemas.Config{Region: region.Region}); err != nil {
+			recordErr(err)
+		}
+
+		client, err := selectClientFromList(c.AWSClients, region.Region)
+		if err != nil {
+			recordErr(err)
+		} else if err := c.ResizingAutoScalingGroupCount(client, canaryASG, 0); err != nil {
+			recordErr(err)
+		} else {
+			for {
+				isTimeout, _ := tool.CheckTimeout(rollbackStartTimestamp, config.Timeout)
+				if isTimeout {
+					recordErr(fmt.Errorf("timeout has been exceeded : %.0f minutes", config.Timeout.Minutes()))
+					break
+				}
+
+				done, err := c.CheckAutoscalingInstanceCount(client, canaryASG, 0)
+				if err != nil {
+					recordErr(err)
+					break
+				}
+				if done {
+					if ok := c.ClearResources(client, canaryASG, config.DisableMetrics); !ok {
+						recordErr(fmt.Errorf("error happened while cleaning rollback resources: %s", canaryASG))
+					}
+					break
+				}
+
+				c.Logger.Info("Rollback autoscaling group is not empty yet... Please waiting...")
+				time.Sleep(config.PollingInterval)
+			}
+		}
+	}
+
+	if retErr == nil {
+		c.StepStatus[constants.StepDeploy] = false
+	}
+	return retErr
+}
+
+// ActiveCanaryAutoScalingGroupName returns only the ASG created for the active canary deployment.
+func (c *Canary) ActiveCanaryAutoScalingGroupName(region string) string {
+	if c.AsgNames == nil {
+		return ""
+	}
+	return c.AsgNames[region]
+}
+
+// CanaryAutoScalingGroupName returns the ASG owned by the active canary deployment.
+func (c *Canary) CanaryAutoScalingGroupName(region string) string {
+	if c.AsgNames != nil && c.AsgNames[region] != "" {
+		return c.AsgNames[region]
+	}
+	return c.LatestAsg[region]
 }
 
 // FinishAdditionalWork processes additional work for the new deployment
@@ -778,9 +883,9 @@ func (c *Canary) DetachLatestCanaryResources(config schemas.Config) error {
 			continue
 		}
 
-		latestASG := c.LatestAsg[region.Region]
-		if latestASG != "" {
-			if err := c.DetachCanaryTargetGroup(latestASG, region, []string{canaryTargetGroupArn}); err != nil {
+		canaryASG := c.CanaryAutoScalingGroupName(region.Region)
+		if canaryASG != "" {
+			if err := c.DetachCanaryTargetGroup(canaryASG, region, []string{canaryTargetGroupArn}); err != nil {
 				return err
 			}
 		}
@@ -794,8 +899,8 @@ func (c *Canary) DetachLatestCanaryResources(config schemas.Config) error {
 		}
 		c.Logger.Debugf("Deleted canary target group: %s", canaryTargetGroupArn)
 
-		if latestASG != "" {
-			if err := c.RemoveCanaryTag(latestASG, region); err != nil {
+		if canaryASG != "" {
+			if err := c.RemoveCanaryTag(canaryASG, region); err != nil {
 				return err
 			}
 		}

--- a/pkg/deployer/canary.go
+++ b/pkg/deployer/canary.go
@@ -41,7 +41,10 @@ type Canary struct {
 	*Deployer
 }
 
-const defaultCanaryWeight = int64(10)
+const (
+	defaultCanaryWeight = int64(10)
+	maxCanaryWeight     = int64(90)
+)
 
 // NewCanary creates new canary deployment deployer
 func NewCanary(h *helper.DeployerHelper) *Canary {
@@ -308,8 +311,8 @@ func (c *Canary) ValidateCanaryDeployment(config schemas.Config, region string) 
 		if regionConfig.Canary.ListenerARN == "" && (regionConfig.Canary.LoadBalancer == "" || regionConfig.Canary.ListenerPort == 0) {
 			return errors.New("canary.listener_arn or canary.load_balancer with canary.listener_port is required for canary deployment")
 		}
-		if regionConfig.Canary.Weight < 0 || regionConfig.Canary.Weight > 99 {
-			return errors.New("canary.weight must be between 0 and 99")
+		if regionConfig.Canary.Weight < 0 || regionConfig.Canary.Weight > maxCanaryWeight {
+			return errors.New("canary.weight must be between 0 and 90")
 		}
 	}
 

--- a/pkg/deployer/canary_test.go
+++ b/pkg/deployer/canary_test.go
@@ -103,6 +103,77 @@ func TestCanaryBakeTimeConfig(t *testing.T) {
 	}
 }
 
+func TestShouldRollbackCanary(t *testing.T) {
+	c := Canary{
+		Deployer: &Deployer{
+			StepStatus: map[int64]bool{constants.StepDeploy: true},
+		},
+	}
+
+	if !c.ShouldRollbackCanary(schemas.Config{}) {
+		t.Fatal("expected rollback after canary deploy step")
+	}
+
+	if c.ShouldRollbackCanary(schemas.Config{CompleteCanary: true}) {
+		t.Fatal("did not expect rollback during complete canary")
+	}
+
+	c.StepStatus[constants.StepDeploy] = false
+	if c.ShouldRollbackCanary(schemas.Config{}) {
+		t.Fatal("did not expect rollback before canary deploy step")
+	}
+}
+
+func TestCanaryAutoScalingGroupNamePrefersActiveDeployment(t *testing.T) {
+	c := Canary{
+		Deployer: &Deployer{
+			AsgNames:  map[string]string{constants.DefaultRegion: "demo-canary-v002"},
+			LatestAsg: map[string]string{constants.DefaultRegion: "demo-stable-v001"},
+		},
+	}
+
+	if got := c.CanaryAutoScalingGroupName(constants.DefaultRegion); got != "demo-canary-v002" {
+		t.Fatalf("expected active canary ASG, got %s", got)
+	}
+}
+
+func TestCanaryAutoScalingGroupNameFallsBackToLatestWithEmptyActiveMap(t *testing.T) {
+	c := Canary{
+		Deployer: &Deployer{
+			AsgNames:  map[string]string{},
+			LatestAsg: map[string]string{constants.DefaultRegion: "demo-canary-v002"},
+		},
+	}
+
+	if got := c.CanaryAutoScalingGroupName(constants.DefaultRegion); got != "demo-canary-v002" {
+		t.Fatalf("expected latest ASG fallback, got %s", got)
+	}
+}
+
+func TestCanaryAutoScalingGroupNameFallsBackToLatestWithNilActiveMap(t *testing.T) {
+	c := Canary{
+		Deployer: &Deployer{
+			LatestAsg: map[string]string{constants.DefaultRegion: "demo-canary-v002"},
+		},
+	}
+
+	if got := c.CanaryAutoScalingGroupName(constants.DefaultRegion); got != "demo-canary-v002" {
+		t.Fatalf("expected latest ASG fallback, got %s", got)
+	}
+}
+
+func TestActiveCanaryAutoScalingGroupNameDoesNotFallbackToLatest(t *testing.T) {
+	c := Canary{
+		Deployer: &Deployer{
+			LatestAsg: map[string]string{constants.DefaultRegion: "demo-stable-v001"},
+		},
+	}
+
+	if got := c.ActiveCanaryAutoScalingGroupName(constants.DefaultRegion); got != "" {
+		t.Fatalf("expected no active canary ASG fallback, got %s", got)
+	}
+}
+
 func TestValidateCanaryDeploymentAllowsListenerLookup(t *testing.T) {
 	c := Canary{
 		Deployer: &Deployer{

--- a/pkg/deployer/canary_test.go
+++ b/pkg/deployer/canary_test.go
@@ -141,6 +141,30 @@ func TestValidateCanaryDeploymentRequiresListenerConfig(t *testing.T) {
 	}
 }
 
+func TestValidateCanaryDeploymentRejectsUnsafeWeight(t *testing.T) {
+	c := Canary{
+		Deployer: &Deployer{
+			DeploymentFlag: map[string]string{},
+			Stack: schemas.Stack{
+				Regions: []schemas.RegionConfig{
+					{
+						Region: constants.DefaultRegion,
+						Canary: schemas.CanaryConfig{
+							LoadBalancer: "demoapp-xyzdapne2-ext",
+							ListenerPort: 443,
+							Weight:       91,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := c.ValidateCanaryDeployment(schemas.Config{}, constants.DefaultRegion); err == nil {
+		t.Fatal("expected canary weight validation error")
+	}
+}
+
 func TestCanaryRunAPITestDelegatesToDeployer(t *testing.T) {
 	logger := Logger.New()
 	logger.SetOutput(io.Discard)

--- a/pkg/deployer/canary_test.go
+++ b/pkg/deployer/canary_test.go
@@ -18,10 +18,15 @@ package deployer
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"testing"
+	"time"
+
+	Logger "github.com/sirupsen/logrus"
 
 	"github.com/DevopsArtFactory/goployer/pkg/constants"
+	"github.com/DevopsArtFactory/goployer/pkg/schemas"
 )
 
 func TestCheckCanaryVersion(t *testing.T) {
@@ -58,5 +63,97 @@ func TestCheckCanaryVersion(t *testing.T) {
 		if output := CheckCanaryVersion(td.Input, region); output != td.Expected {
 			t.Errorf("expected: %d, output: %d", td.Expected, output)
 		}
+	}
+}
+
+func TestCanaryWeights(t *testing.T) {
+	region := schemas.RegionConfig{
+		Canary: schemas.CanaryConfig{
+			Weight: 25,
+		},
+	}
+
+	stable, canary := CanaryWeights(region, false)
+	if stable != 75 || canary != 25 {
+		t.Fatalf("expected 75/25 canary weights, got %d/%d", stable, canary)
+	}
+
+	stable, canary = CanaryWeights(region, true)
+	if stable != 100 || canary != 0 {
+		t.Fatalf("expected 100/0 complete weights, got %d/%d", stable, canary)
+	}
+}
+
+func TestCanaryWeightsDefault(t *testing.T) {
+	stable, canary := CanaryWeights(schemas.RegionConfig{}, false)
+	if stable != 90 || canary != 10 {
+		t.Fatalf("expected default 90/10 canary weights, got %d/%d", stable, canary)
+	}
+}
+
+func TestCanaryBakeTimeConfig(t *testing.T) {
+	region := schemas.RegionConfig{
+		Canary: schemas.CanaryConfig{
+			BakeTime: 10 * time.Minute,
+		},
+	}
+
+	if region.Canary.BakeTime != 10*time.Minute {
+		t.Fatalf("expected 10m bake time, got %s", region.Canary.BakeTime)
+	}
+}
+
+func TestValidateCanaryDeploymentAllowsListenerLookup(t *testing.T) {
+	c := Canary{
+		Deployer: &Deployer{
+			DeploymentFlag: map[string]string{},
+			Stack: schemas.Stack{
+				Regions: []schemas.RegionConfig{
+					{
+						Region: constants.DefaultRegion,
+						Canary: schemas.CanaryConfig{
+							LoadBalancer: "demoapp-xyzdapne2-ext",
+							ListenerPort: 443,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := c.ValidateCanaryDeployment(schemas.Config{}, constants.DefaultRegion); err != nil {
+		t.Fatalf("unexpected validation error: %s", err)
+	}
+}
+
+func TestValidateCanaryDeploymentRequiresListenerConfig(t *testing.T) {
+	c := Canary{
+		Deployer: &Deployer{
+			DeploymentFlag: map[string]string{},
+			Stack: schemas.Stack{
+				Regions: []schemas.RegionConfig{{Region: constants.DefaultRegion}},
+			},
+		},
+	}
+
+	if err := c.ValidateCanaryDeployment(schemas.Config{}, constants.DefaultRegion); err == nil {
+		t.Fatal("expected listener validation error")
+	}
+}
+
+func TestCanaryRunAPITestDelegatesToDeployer(t *testing.T) {
+	logger := Logger.New()
+	logger.SetOutput(io.Discard)
+
+	c := Canary{
+		Deployer: &Deployer{
+			Stack:      schemas.Stack{APITestEnabled: false},
+			Logger:     logger,
+			StepStatus: map[int64]bool{constants.StepGatherMetrics: true, constants.StepCleanChecking: true},
+		},
+	}
+
+	if err := c.RunAPITest(schemas.Config{CompleteCanary: true}); err != nil {
+		t.Fatalf("unexpected API test error: %s", err)
 	}
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -346,16 +346,30 @@ func (r Runner) Deploy() error {
 	}
 
 	// Health checking step
+	errs = make(chan error, len(deployers))
 	for _, d := range deployers {
 		wg.Add(1)
 		go func(deployer deployer.DeployManager) {
 			defer wg.Done()
 			if err := deployer.HealthChecking(r.Builder.Config); err != nil {
 				r.Logger.Errorf("[StepHealthCheck] check new deployment error occurred: %s", err.Error())
+				errs <- err
 			}
 		}(d)
 	}
-	wg.Wait()
+	go func() {
+		wg.Wait()
+		close(errs)
+	}()
+	errFlag = nil
+	for err := range errs {
+		if errFlag == nil {
+			errFlag = err
+		}
+	}
+	if errFlag != nil {
+		return errFlag
+	}
 
 	for _, d := range deployers {
 		wg.Add(1)

--- a/pkg/schemas/config.go
+++ b/pkg/schemas/config.go
@@ -353,6 +353,9 @@ type RegionConfig struct {
 	// Target group list of load balancer
 	TargetGroups []string `yaml:"target_groups"`
 
+	// Canary deployment configuration
+	Canary CanaryConfig `yaml:"canary,omitempty"`
+
 	// List of  load balancers
 	LoadBalancers []string `yaml:"loadbalancers"`
 
@@ -370,6 +373,27 @@ type RegionConfig struct {
 
 	// HTTP PUT response hop limit for IMDSv2 (default: 1)
 	HttpPutResponseHopLimit int64 `yaml:"http_put_response_hop_limit,omitempty"`
+}
+
+// CanaryConfig configures weighted target group canary deployment
+type CanaryConfig struct {
+	// Existing listener ARN whose default action forwards to the production target group
+	ListenerARN string `yaml:"listener_arn"`
+
+	// Existing load balancer name that owns the canary listener
+	LoadBalancer string `yaml:"load_balancer,omitempty"`
+
+	// Existing listener port whose default action forwards to the production target group
+	ListenerPort int32 `yaml:"listener_port,omitempty"`
+
+	// Existing listener protocol. Optional when listener_port is unique
+	ListenerProtocol string `yaml:"listener_protocol,omitempty"`
+
+	// Time to keep canary traffic before finishing the canary deployment step
+	BakeTime time.Duration `yaml:"bake_time,omitempty"`
+
+	// Percentage of traffic to send to the canary target group. Defaults to `10`
+	Weight int64 `yaml:"weight,omitempty"`
 }
 
 // ENI Configuration

--- a/pkg/schemas/config.go
+++ b/pkg/schemas/config.go
@@ -392,7 +392,7 @@ type CanaryConfig struct {
 	// Time to keep canary traffic before finishing the canary deployment step
 	BakeTime time.Duration `yaml:"bake_time,omitempty"`
 
-	// Percentage of traffic to send to the canary target group. Defaults to `10`
+	// Percentage of traffic to send to the canary target group. Defaults to `10`; maximum is `90`
 	Weight int64 `yaml:"weight,omitempty"`
 }
 


### PR DESCRIPTION
## What changed

Closes #189

### Weighted target group canary

- Replaced the old canary-specific load balancer path with weighted target groups on an existing ALB/NLB listener default action.
- Canary deployment now copies the original target group, creates a canary target group, and attaches the new canary ASG only to that canary target group.
- After the canary ASG is created, the listener is first updated with `stable=100` and `canary=0` so the canary target group becomes active for load balancer health checks. Without this, AWS reports the target group as `unused`.
- After canary health checks pass, the listener is updated to the configured `canary.weight` value. The default remains `10`.
- `--complete-canary` attaches the canary ASG to the original target group, restores the listener to a single original target group forward action, then detaches and deletes the canary target group.
- Fixed a `complete-canary` nil panic caused by missing `AppliedCapacity` during health checks.
- Fixed the complete cleanup loop so it does not wait on the promoted latest ASG as if it were an old ASG.
- Fixed `Canary.RunAPITest`, which previously called itself recursively instead of delegating to `Deployer.RunAPITest`.

### Manifest UX

The manifest no longer needs a long listener ARN. New manifests can use load balancer name plus listener port:

```yaml
canary:
  load_balancer: demoapp-xyzdapne2-ext
  listener_port: 443
  listener_protocol: HTTPS
  weight: 10
  bake_time: 10m
```

- `canary.listener_arn` is still supported for backward compatibility.
- If `listener_arn` is omitted, Goployer resolves the listener with `DescribeLoadBalancers` and `DescribeListeners`.
- `listener_protocol` is optional and only used to make the listener match explicit.

### Bake time

- Added `canary.bake_time`.
- After the canary weight is applied, the deploy command waits for the configured duration before exiting.
- This is only a time gate. It does not evaluate CloudWatch alarms or API tests.

### Docs and examples

- Added English and Korean docs for weighted canary deployments.
- Documented ALB/NLB constraints:
  - only listener default actions are supported
  - NLB weighted listeners cannot mix TCP, TLS, and UDP target groups on the same listener
  - weighted target groups must use the same IP address type
  - NLB weight changes apply to new flows, not existing connections
- Added demo Python userdata scripts and demo manifests.
- Regenerated the JSON schema.

## What was tested

### Local checks

- `go test -count=1 ./pkg/... ./cmd/... ./hack/...`
- `make linters`
- `git diff --check`

### Unit tests

Added or updated tests for:

- weighted forward action generation
- canary weight/default weight calculation
- listener lookup manifest validation
- bake time configuration
- `Canary.RunAPITest` delegation to `Deployer.RunAPITest`

### Live AWS validation

Validated the full flow in a test AWS account using these existing resources:

- VPC: `vpc-021c0886b3de5a28b`
- ALB: `demoapp-xyzdapne2-ext`
- stable target group: `demoapp-xyzdapne2-ext`
- listener: `HTTPS:443`
- app security group: `demoapp-xyzd_apnortheast2-app`

Validation results:

- Stable deploy succeeded: `demoapp-xyzd_apnortheast2-v000`.
- Canary deploy succeeded: `demoapp-xyzd_apnortheast2-v001`.
- Listener weighted forward was confirmed as `stable=90`, `canary=10`.
- 60 ALB requests returned `stable=49`, `canary=11`.
- `--complete-canary` restored the listener to a single original target group forward action.
- Canary target group `demoapp-xyzd-canary-v001` was deleted.
- Final ASG state: `demoapp-xyzd_apnortheast2-v001`, desired/min/max `1/1/1`, target health `healthy`.
- Final ALB responses:

```json
{"app":"demoapp","version":"canary","path":"/"}
{"status":"UP"}
```

## Remaining work

Tracked in #190

- `canary.bake_time` only waits. It does not decide whether the canary is safe to promote.
- Add CloudWatch alarm based promotion gates, for example:
  - canary target group `UnHealthyHostCount == 0`
  - canary target group `HTTPCode_Target_5XX_Count == 0`
  - canary target group `TargetResponseTime` below a configured threshold
- Decide whether the existing API test feature should become a `--complete-canary` promotion gate.
- Define rollback behavior when promotion gates fail.
- NLB support follows the ELBV2 listener/target group API model and AWS documentation, but this PR was not live-tested against an NLB.
- Host/path listener rule based canary routing is still out of scope. This PR supports listener default actions only.

## Operational notes

- New manifests should prefer `load_balancer` + `listener_port` over direct `listener_arn`.
- The canary ASG is not attached to the original target group when canary starts. It is attached to the original target group during `--complete-canary`.
- `.gitignore` has an unrelated local `.omx/` change in my working tree; it is intentionally not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added weighted canary deployments for ALB/NLB, including start and `--complete-canary` completion flow.
  * Expanded deployment configuration with canary routing settings plus richer EBS, network interface, and region options.
  * Added example canary/stable manifests and demo startup scripts.

* **Documentation**
  * Added new English and Korean guides for weighted canary behavior, constraints, and CLI workflow.

* **Bug Fixes**
  * Health-check failures in deployment now properly stop the deploy sequence and surface the first error.

* **Tests**
  * Added coverage for weighted listener actions and canary weight/rollback/validation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
