### PR TITLE
Roll back failed canary health checks

### DIFF
--- a/docs/content/en/docs/Concepts/canary.md
+++ b/docs/content/en/docs/Concepts/canary.md
@@ -18,6 +18,18 @@ This mode reuses the existing load balancer listener default action instead of c
 
 This implementation supports listener default actions. Listener rule based canary routing is not supported yet.
 
+## Health check rollback
+
+If the canary Auto Scaling group fails health checks or the health check step times out after the deploy step, Goployer automatically rolls the canary back before returning the error:
+
+1. Restore the listener default action to the original target group.
+2. Detach and delete the canary target group.
+3. Scale the failed canary Auto Scaling group to `0`.
+4. Wait until the failed canary Auto Scaling group has no instances.
+5. Delete the failed canary Auto Scaling group and its launch template.
+
+When rollback succeeds, Goployer clears the canary deploy step status so later finish/cleanup phases do not promote the failed canary.
+
 ## Manifest
 
 ```yaml
@@ -48,6 +60,7 @@ regions:
 - NLB weight changes apply to new flows, not existing connections.
 - Goployer treats `canary.weight` as a percentage, so valid values are `0` through `90`.
 - `canary.bake_time` only waits. CloudWatch alarm or API test based promotion gates should be added separately.
+- Automatic rollback is tied to Goployer health check failures. It does not monitor CloudWatch alarms after the deploy command exits.
 
 ## Commands
 

--- a/docs/content/ko/docs/Concepts/canary.md
+++ b/docs/content/ko/docs/Concepts/canary.md
@@ -18,6 +18,18 @@ Goployer의 canary 배포는 ALB/NLB weighted target groups를 사용합니다.
 
 현재 구현은 listener default action만 지원합니다. host/path 기반 listener rule canary는 아직 지원하지 않습니다.
 
+## Health check rollback
+
+Canary Auto Scaling group이 health check에 실패하거나 health check 단계에서 timeout되면, Goployer는 에러를 반환하기 전에 canary를 자동 rollback합니다.
+
+1. Listener default action을 original target group으로 복구합니다.
+2. Canary target group을 Auto Scaling group에서 분리하고 삭제합니다.
+3. 실패한 canary Auto Scaling group 크기를 `0`으로 줄입니다.
+4. 실패한 canary Auto Scaling group의 instance가 모두 없어질 때까지 기다립니다.
+5. 실패한 canary Auto Scaling group과 launch template을 삭제합니다.
+
+Rollback이 성공하면 이후 finish/cleanup 단계에서 실패한 canary가 승격되지 않도록 canary deploy step 상태를 해제합니다.
+
 ## Manifest
 
 ```yaml
@@ -48,6 +60,7 @@ regions:
 - NLB weight 변경은 기존 연결이 아니라 새 flow부터 반영됩니다.
 - Goployer의 `canary.weight`는 percentage 값이라 `0`부터 `90`까지만 허용합니다.
 - `canary.bake_time`은 시간 대기만 수행합니다. CloudWatch alarm이나 API test 기반 자동 승격 판단은 별도 승격 조건으로 구성해야 합니다.
+- 자동 rollback은 Goployer health check 실패에만 연결됩니다. 배포 명령이 종료된 뒤 CloudWatch alarm을 계속 감시하지는 않습니다.
 
 ## Commands
 

--- a/pkg/deployer/canary.go
+++ b/pkg/deployer/canary.go
@@ -148,12 +148,19 @@ func (c *Canary) HealthChecking(config schemas.Config) error {
 		c.Logger.Debugf("Start Timestamp: %d, timeout: %s", config.StartTimestamp, config.Timeout)
 		isTimeout, _ := tool.CheckTimeout(config.StartTimestamp, config.Timeout)
 		if isTimeout {
-			return fmt.Errorf("timeout has been exceeded : %.0f minutes", config.Timeout.Minutes())
+			err := fmt.Errorf("timeout has been exceeded : %.0f minutes", config.Timeout.Minutes())
+			if rollbackErr := c.RollbackCanaryDeployment(config); rollbackErr != nil {
+				return fmt.Errorf("%w; rollback failed: %s", err, rollbackErr)
+			}
+			return err
 		}
 
 		isDone, err := c.Deployer.HealthChecking(config)
 		if err != nil {
-			return errors.New("error happened while health checking")
+			if rollbackErr := c.RollbackCanaryDeployment(config); rollbackErr != nil {
+				return fmt.Errorf("error happened while health checking: %w; rollback failed: %s", err, rollbackErr)
+			}
+			return fmt.Errorf("error happened while health checking: %w", err)
 		}
 
 		if isDone {
@@ -164,6 +171,89 @@ func (c *Canary) HealthChecking(config schemas.Config) error {
 	}
 
 	return nil
+}
+
+// ShouldRollbackCanary returns whether a failed health check owns canary resources to clean up.
+func (c *Canary) ShouldRollbackCanary(config schemas.Config) bool {
+	return c.StepStatus[constants.StepDeploy] && !config.CompleteCanary
+}
+
+// RollbackCanaryDeployment restores listener traffic and removes failed canary resources.
+func (c *Canary) RollbackCanaryDeployment(config schemas.Config) error {
+	if !c.ShouldRollbackCanary(config) {
+		return nil
+	}
+
+	var retErr error
+	recordErr := func(err error) {
+		if err != nil && retErr == nil {
+			retErr = err
+		}
+	}
+	rollbackStartTimestamp := time.Now().Unix()
+
+	for _, region := range c.Stack.Regions {
+		if config.Region != "" && config.Region != region.Region {
+			c.Logger.Debug("This region is skipped by user : " + region.Region)
+			continue
+		}
+
+		if c.OriginalTargetGroupArn[region.Region] != "" {
+			if err := c.ModifyListenerToStableTargetGroup(region, 100, 0); err != nil {
+				recordErr(err)
+			}
+		}
+
+		canaryASG := c.CanaryAutoScalingGroupName(region.Region)
+		if err := c.DetachLatestCanaryResources(schemas.Config{Region: region.Region}); err != nil {
+			recordErr(err)
+		}
+
+		if canaryASG != "" {
+			client, err := selectClientFromList(c.AWSClients, region.Region)
+			if err != nil {
+				recordErr(err)
+			} else if err := c.ResizingAutoScalingGroupCount(client, canaryASG, 0); err != nil {
+				recordErr(err)
+			} else {
+				for {
+					isTimeout, _ := tool.CheckTimeout(rollbackStartTimestamp, config.Timeout)
+					if isTimeout {
+						recordErr(fmt.Errorf("timeout has been exceeded : %.0f minutes", config.Timeout.Minutes()))
+						break
+					}
+
+					done, err := c.CheckAutoscalingInstanceCount(client, canaryASG, 0)
+					if err != nil {
+						recordErr(err)
+						break
+					}
+					if done {
+						if ok := c.ClearResources(client, canaryASG, config.DisableMetrics); !ok {
+							recordErr(fmt.Errorf("error happened while cleaning rollback resources: %s", canaryASG))
+						}
+						break
+					}
+
+					c.Logger.Info("Rollback autoscaling group is not empty yet... Please waiting...")
+					time.Sleep(config.PollingInterval)
+				}
+			}
+		}
+	}
+
+	if retErr == nil {
+		c.StepStatus[constants.StepDeploy] = false
+	}
+	return retErr
+}
+
+// CanaryAutoScalingGroupName returns the ASG owned by the active canary deployment.
+func (c *Canary) CanaryAutoScalingGroupName(region string) string {
+	if c.AsgNames != nil && c.AsgNames[region] != "" {
+		return c.AsgNames[region]
+	}
+	return c.LatestAsg[region]
 }
 
 // FinishAdditionalWork processes additional work for the new deployment
@@ -778,9 +868,9 @@ func (c *Canary) DetachLatestCanaryResources(config schemas.Config) error {
 			continue
 		}
 
-		latestASG := c.LatestAsg[region.Region]
-		if latestASG != "" {
-			if err := c.DetachCanaryTargetGroup(latestASG, region, []string{canaryTargetGroupArn}); err != nil {
+		canaryASG := c.CanaryAutoScalingGroupName(region.Region)
+		if canaryASG != "" {
+			if err := c.DetachCanaryTargetGroup(canaryASG, region, []string{canaryTargetGroupArn}); err != nil {
 				return err
 			}
 		}
@@ -794,8 +884,8 @@ func (c *Canary) DetachLatestCanaryResources(config schemas.Config) error {
 		}
 		c.Logger.Debugf("Deleted canary target group: %s", canaryTargetGroupArn)
 
-		if latestASG != "" {
-			if err := c.RemoveCanaryTag(latestASG, region); err != nil {
+		if canaryASG != "" {
+			if err := c.RemoveCanaryTag(canaryASG, region); err != nil {
 				return err
 			}
 		}

--- a/pkg/deployer/canary.go
+++ b/pkg/deployer/canary.go
@@ -201,43 +201,50 @@ func (c *Canary) RollbackCanaryDeployment(config schemas.Config) error {
 		if c.OriginalTargetGroupArn[region.Region] != "" {
 			if err := c.ModifyListenerToStableTargetGroup(region, 100, 0); err != nil {
 				recordErr(err)
+				continue
 			}
+		} else {
+			recordErr(fmt.Errorf("original target group is missing for rollback region: %s", region.Region))
+			continue
 		}
 
-		canaryASG := c.CanaryAutoScalingGroupName(region.Region)
+		canaryASG := c.ActiveCanaryAutoScalingGroupName(region.Region)
+		if canaryASG == "" {
+			recordErr(fmt.Errorf("active canary autoscaling group is missing for rollback region: %s", region.Region))
+			continue
+		}
+
 		if err := c.DetachLatestCanaryResources(schemas.Config{Region: region.Region}); err != nil {
 			recordErr(err)
 		}
 
-		if canaryASG != "" {
-			client, err := selectClientFromList(c.AWSClients, region.Region)
-			if err != nil {
-				recordErr(err)
-			} else if err := c.ResizingAutoScalingGroupCount(client, canaryASG, 0); err != nil {
-				recordErr(err)
-			} else {
-				for {
-					isTimeout, _ := tool.CheckTimeout(rollbackStartTimestamp, config.Timeout)
-					if isTimeout {
-						recordErr(fmt.Errorf("timeout has been exceeded : %.0f minutes", config.Timeout.Minutes()))
-						break
-					}
-
-					done, err := c.CheckAutoscalingInstanceCount(client, canaryASG, 0)
-					if err != nil {
-						recordErr(err)
-						break
-					}
-					if done {
-						if ok := c.ClearResources(client, canaryASG, config.DisableMetrics); !ok {
-							recordErr(fmt.Errorf("error happened while cleaning rollback resources: %s", canaryASG))
-						}
-						break
-					}
-
-					c.Logger.Info("Rollback autoscaling group is not empty yet... Please waiting...")
-					time.Sleep(config.PollingInterval)
+		client, err := selectClientFromList(c.AWSClients, region.Region)
+		if err != nil {
+			recordErr(err)
+		} else if err := c.ResizingAutoScalingGroupCount(client, canaryASG, 0); err != nil {
+			recordErr(err)
+		} else {
+			for {
+				isTimeout, _ := tool.CheckTimeout(rollbackStartTimestamp, config.Timeout)
+				if isTimeout {
+					recordErr(fmt.Errorf("timeout has been exceeded : %.0f minutes", config.Timeout.Minutes()))
+					break
 				}
+
+				done, err := c.CheckAutoscalingInstanceCount(client, canaryASG, 0)
+				if err != nil {
+					recordErr(err)
+					break
+				}
+				if done {
+					if ok := c.ClearResources(client, canaryASG, config.DisableMetrics); !ok {
+						recordErr(fmt.Errorf("error happened while cleaning rollback resources: %s", canaryASG))
+					}
+					break
+				}
+
+				c.Logger.Info("Rollback autoscaling group is not empty yet... Please waiting...")
+				time.Sleep(config.PollingInterval)
 			}
 		}
 	}
@@ -246,6 +253,14 @@ func (c *Canary) RollbackCanaryDeployment(config schemas.Config) error {
 		c.StepStatus[constants.StepDeploy] = false
 	}
 	return retErr
+}
+
+// ActiveCanaryAutoScalingGroupName returns only the ASG created for the active canary deployment.
+func (c *Canary) ActiveCanaryAutoScalingGroupName(region string) string {
+	if c.AsgNames == nil {
+		return ""
+	}
+	return c.AsgNames[region]
 }
 
 // CanaryAutoScalingGroupName returns the ASG owned by the active canary deployment.

--- a/pkg/deployer/canary_test.go
+++ b/pkg/deployer/canary_test.go
@@ -137,7 +137,7 @@ func TestCanaryAutoScalingGroupNamePrefersActiveDeployment(t *testing.T) {
 	}
 }
 
-func TestCanaryAutoScalingGroupNameFallsBackToLatest(t *testing.T) {
+func TestCanaryAutoScalingGroupNameFallsBackToLatestWithEmptyActiveMap(t *testing.T) {
 	c := Canary{
 		Deployer: &Deployer{
 			AsgNames:  map[string]string{},
@@ -147,6 +147,30 @@ func TestCanaryAutoScalingGroupNameFallsBackToLatest(t *testing.T) {
 
 	if got := c.CanaryAutoScalingGroupName(constants.DefaultRegion); got != "demo-canary-v002" {
 		t.Fatalf("expected latest ASG fallback, got %s", got)
+	}
+}
+
+func TestCanaryAutoScalingGroupNameFallsBackToLatestWithNilActiveMap(t *testing.T) {
+	c := Canary{
+		Deployer: &Deployer{
+			LatestAsg: map[string]string{constants.DefaultRegion: "demo-canary-v002"},
+		},
+	}
+
+	if got := c.CanaryAutoScalingGroupName(constants.DefaultRegion); got != "demo-canary-v002" {
+		t.Fatalf("expected latest ASG fallback, got %s", got)
+	}
+}
+
+func TestActiveCanaryAutoScalingGroupNameDoesNotFallbackToLatest(t *testing.T) {
+	c := Canary{
+		Deployer: &Deployer{
+			LatestAsg: map[string]string{constants.DefaultRegion: "demo-stable-v001"},
+		},
+	}
+
+	if got := c.ActiveCanaryAutoScalingGroupName(constants.DefaultRegion); got != "" {
+		t.Fatalf("expected no active canary ASG fallback, got %s", got)
 	}
 }
 

--- a/pkg/deployer/canary_test.go
+++ b/pkg/deployer/canary_test.go
@@ -103,6 +103,53 @@ func TestCanaryBakeTimeConfig(t *testing.T) {
 	}
 }
 
+func TestShouldRollbackCanary(t *testing.T) {
+	c := Canary{
+		Deployer: &Deployer{
+			StepStatus: map[int64]bool{constants.StepDeploy: true},
+		},
+	}
+
+	if !c.ShouldRollbackCanary(schemas.Config{}) {
+		t.Fatal("expected rollback after canary deploy step")
+	}
+
+	if c.ShouldRollbackCanary(schemas.Config{CompleteCanary: true}) {
+		t.Fatal("did not expect rollback during complete canary")
+	}
+
+	c.StepStatus[constants.StepDeploy] = false
+	if c.ShouldRollbackCanary(schemas.Config{}) {
+		t.Fatal("did not expect rollback before canary deploy step")
+	}
+}
+
+func TestCanaryAutoScalingGroupNamePrefersActiveDeployment(t *testing.T) {
+	c := Canary{
+		Deployer: &Deployer{
+			AsgNames:  map[string]string{constants.DefaultRegion: "demo-canary-v002"},
+			LatestAsg: map[string]string{constants.DefaultRegion: "demo-stable-v001"},
+		},
+	}
+
+	if got := c.CanaryAutoScalingGroupName(constants.DefaultRegion); got != "demo-canary-v002" {
+		t.Fatalf("expected active canary ASG, got %s", got)
+	}
+}
+
+func TestCanaryAutoScalingGroupNameFallsBackToLatest(t *testing.T) {
+	c := Canary{
+		Deployer: &Deployer{
+			AsgNames:  map[string]string{},
+			LatestAsg: map[string]string{constants.DefaultRegion: "demo-canary-v002"},
+		},
+	}
+
+	if got := c.CanaryAutoScalingGroupName(constants.DefaultRegion); got != "demo-canary-v002" {
+		t.Fatalf("expected latest ASG fallback, got %s", got)
+	}
+}
+
 func TestValidateCanaryDeploymentAllowsListenerLookup(t *testing.T) {
 	c := Canary{
 		Deployer: &Deployer{

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -346,7 +346,7 @@ func (r Runner) Deploy() error {
 	}
 
 	// Health checking step
-	errs = make(chan error)
+	errs = make(chan error, len(deployers))
 	for _, d := range deployers {
 		wg.Add(1)
 		go func(deployer deployer.DeployManager) {
@@ -361,7 +361,12 @@ func (r Runner) Deploy() error {
 		wg.Wait()
 		close(errs)
 	}()
-	errFlag = checkError(errs)
+	errFlag = nil
+	for err := range errs {
+		if errFlag == nil {
+			errFlag = err
+		}
+	}
 	if errFlag != nil {
 		return errFlag
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -346,16 +346,25 @@ func (r Runner) Deploy() error {
 	}
 
 	// Health checking step
+	errs = make(chan error)
 	for _, d := range deployers {
 		wg.Add(1)
 		go func(deployer deployer.DeployManager) {
 			defer wg.Done()
 			if err := deployer.HealthChecking(r.Builder.Config); err != nil {
 				r.Logger.Errorf("[StepHealthCheck] check new deployment error occurred: %s", err.Error())
+				errs <- err
 			}
 		}(d)
 	}
-	wg.Wait()
+	go func() {
+		wg.Wait()
+		close(errs)
+	}()
+	errFlag = checkError(errs)
+	if errFlag != nil {
+		return errFlag
+	}
 
 	for _, d := range deployers {
 		wg.Add(1)


### PR DESCRIPTION
## Implemented

- Added automatic rollback for canary health check failures and health check timeouts.
- Restores the listener default action back to the original target group before returning the health failure.
- Detaches and deletes the canary target group created for the failed rollout.
- Scales the failed canary Auto Scaling group to `0`, waits for its instances to terminate, then deletes the Auto Scaling group and launch template.
- Stops the runner when the health check step returns an error, so failed canaries do not continue into later deployment phases.
- Tracks the active canary Auto Scaling group via `AsgNames` instead of using `LatestAsg`, which represents the stable group during the initial canary deployment.
- Added English and Korean documentation for health check rollback behavior and its scope.

## Tested

- `env -u GOROOT go test ./pkg/deployer -run TestShouldRollbackCanary`
- `env -u GOROOT go test ./pkg/deployer ./pkg/runner`
- `env -u GOROOT go test -count=1 ./pkg/... ./cmd/... ./hack/...`
- `env -u GOROOT make linters`
- `git diff --check`
- Live AWS rollback test in `ap-northeast-2` using `demoapp-xyzdapne2-ext`:
  - Deployed an intentionally unhealthy canary userdata script.
  - Confirmed target health stayed `unhealthy`.
  - Confirmed the deploy command returned `GOPLOYER_EXIT:1`.
  - Confirmed the listener was restored to the stable target group.
  - Confirmed stable ASG `demoapp-xyzd_apnortheast2-v001` remained `1/1/1` and healthy.
  - Confirmed canary target group `demoapp-xyzd-canary-v001` was deleted.
  - Confirmed canary v002 launch templates were removed.

Note: `make linters` failed once with the local `GOROOT` pointing at a gvm Go install whose export data did not match the active Go tool version. Re-running with `env -u GOROOT` passed.

## Remaining

- CloudWatch alarm or synthetic-test based post-deploy rollback is still not implemented. This PR only rolls back failures observed by Goployer's health check step before the deploy command exits.
- Listener rule based canary routing remains outside this PR and the stacked weighted target group PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic canary rollback handling when health checks fail or time out.
  * Canary rollback now restores traffic, removes failed canary resources, and prevents later promotion of a failed deployment.

* **Bug Fixes**
  * Health check failures now stop the deployment instead of being logged and ignored.
  * Clarified that automatic rollback only applies to the built-in health check flow, not post-deploy alarm monitoring.

* **Documentation**
  * Updated canary deployment docs in English and Korean with rollback behavior and constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->